### PR TITLE
chore: bump tuishell to v0.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.2
 	charm.land/glamour/v2 v2.0.0
 	charm.land/lipgloss/v2 v2.0.2
-	github.com/felipeospina21/tuishell v0.2.0
+	github.com/felipeospina21/tuishell v0.3.0
 	github.com/spf13/viper v1.21.0
 	golang.org/x/net v0.47.0
 )

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/felipeospina21/tuishell v0.2.0 h1:sZ3UmHBQ/3kAo65Z5HAgaBx7fbWFwPEZjSNZ863rG4E=
-github.com/felipeospina21/tuishell v0.2.0/go.mod h1:PdkAVJRM2ug1qKEuW+myzWJy0Q5sILUlU+gMN6sU/h0=
+github.com/felipeospina21/tuishell v0.3.0 h1:bPScJsLLucNQN5+yH0bW+TVtfv993qw7bCLXCOhn39c=
+github.com/felipeospina21/tuishell v0.3.0/go.mod h1:PdkAVJRM2ug1qKEuW+myzWJy0Q5sILUlU+gMN6sU/h0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=


### PR DESCRIPTION
Bump tuishell to v0.3.0 — includes shell-level clipboard, esc, and fullscreen defaults.