### PR TITLE
feat: add issue status transitions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.2
 	charm.land/glamour/v2 v2.0.0
 	charm.land/lipgloss/v2 v2.0.2
-	github.com/felipeospina21/tuishell v0.3.0
+	github.com/felipeospina21/tuishell v0.4.0
 	github.com/spf13/viper v1.21.0
 	golang.org/x/net v0.47.0
 )

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/felipeospina21/tuishell v0.3.0 h1:bPScJsLLucNQN5+yH0bW+TVtfv993qw7bCLXCOhn39c=
-github.com/felipeospina21/tuishell v0.3.0/go.mod h1:PdkAVJRM2ug1qKEuW+myzWJy0Q5sILUlU+gMN6sU/h0=
+github.com/felipeospina21/tuishell v0.4.0 h1:thl2CYw6wdN/PnbRYZFfTew+dTpIFBGemNfYYT203PE=
+github.com/felipeospina21/tuishell v0.4.0/go.mod h1:PdkAVJRM2ug1qKEuW+myzWJy0Q5sILUlU+gMN6sU/h0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=

--- a/internal/jira/client.go
+++ b/internal/jira/client.go
@@ -30,6 +30,32 @@ func NewClient(cfg *config.Config) *Client {
 	}
 }
 
+func (c *Client) post(path string, body any) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", c.baseURL+path, strings.NewReader(string(data)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("jira: HTTP %d — %s", resp.StatusCode, b)
+	}
+	return nil
+}
+
 func (c *Client) get(path string, out any) error {
 	req, err := http.NewRequest("GET", c.baseURL+path, nil)
 	if err != nil {

--- a/internal/jira/mock.go
+++ b/internal/jira/mock.go
@@ -10,6 +10,13 @@ func sp(v float64) *float64 { return &v }
 
 var mockSprint = "com.atlassian.greenhopper.service.sprint.Sprint@abc[name=Sprint 42,state=ACTIVE,startDate=2026-04-01T08:00:00.000-05:00,endDate=2026-04-15T08:00:00.000-05:00]"
 
+var MockTransitions = []Transition{
+	{ID: "11", Name: "To Do", To: NameField{Name: "To Do"}},
+	{ID: "21", Name: "In Progress", To: NameField{Name: "In Progress"}},
+	{ID: "31", Name: "In Review", To: NameField{Name: "In Review"}},
+	{ID: "41", Name: "Done", To: NameField{Name: "Done"}},
+}
+
 var MockIssues = []Issue{
 	{
 		Key: "PROJ-1042",

--- a/internal/jira/transitions.go
+++ b/internal/jira/transitions.go
@@ -1,0 +1,40 @@
+package jira
+
+import (
+	"fmt"
+	"time"
+)
+
+// Transition represents an available status transition for an issue.
+type Transition struct {
+	ID   string    `json:"id"`
+	Name string    `json:"name"`
+	To   NameField `json:"to"`
+}
+
+type transitionsResponse struct {
+	Transitions []Transition `json:"transitions"`
+}
+
+// GetTransitions fetches available transitions for an issue.
+func (c *Client) GetTransitions(issueKey string) ([]Transition, error) {
+	if c.devMode {
+		time.Sleep(500 * time.Millisecond)
+		return MockTransitions, nil
+	}
+	var resp transitionsResponse
+	if err := c.get(fmt.Sprintf("/rest/api/2/issue/%s/transitions", issueKey), &resp); err != nil {
+		return nil, err
+	}
+	return resp.Transitions, nil
+}
+
+// DoTransition executes a status transition on an issue.
+func (c *Client) DoTransition(issueKey, transitionID string) error {
+	if c.devMode {
+		time.Sleep(500 * time.Millisecond)
+		return nil
+	}
+	body := map[string]any{"transition": map[string]string{"id": transitionID}}
+	return c.post(fmt.Sprintf("/rest/api/2/issue/%s/transitions", issueKey), body)
+}

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/felipeospina21/jiraf/internal/tui/icon"
 	"github.com/felipeospina21/jiraf/internal/tui/issues"
 	"github.com/felipeospina21/tuishell"
+	"github.com/felipeospina21/tuishell/popover"
 	"github.com/felipeospina21/tuishell/shell"
 	"github.com/felipeospina21/tuishell/style"
 )
@@ -36,6 +37,11 @@ type Model struct {
 	Shell   shell.Model
 	Details *details.Model
 	client  *jira.Client
+
+	// Transition state
+	pendingTransition  string // issue key awaiting transition
+	transitionPicker   popover.ListModel
+	transitionIDByName map[string]string
 }
 
 func NewApp() tea.Model {
@@ -64,11 +70,22 @@ func NewApp() tea.Model {
 		RightPanelStyle: rightPanelStyle,
 	})
 
-	return Model{Shell: s, Details: &det, client: client}
+	return Model{Shell: s, Details: &det, client: client, transitionPicker: popover.NewList(theme)}
 }
 
 func (m Model) Init() tea.Cmd {
 	return m.Shell.Init()
+}
+
+// TransitionsFetchedMsg carries the result of fetching available transitions.
+type TransitionsFetchedMsg struct {
+	Transitions []jira.Transition
+	Err         error
+}
+
+// TransitionDoneMsg carries the result of executing a transition.
+type TransitionDoneMsg struct {
+	Err error
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -94,10 +111,81 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Batch(cmds...)
 
+	case issues.TransitionMsg:
+		m.pendingTransition = msg.Issue.Key
+		return m, func() tea.Msg {
+			return tuishell.StartTaskMsg{Cmd: m.fetchTransitions(msg.Issue.Key)}
+		}
+
+	case TransitionsFetchedMsg:
+		if msg.Err != nil {
+			m.pendingTransition = ""
+			return m, func() tea.Msg {
+				return tuishell.FinishTaskMsg{Err: msg.Err}
+			}
+		}
+		items := make([]tuishell.ListPopoverItem, len(msg.Transitions))
+		m.transitionIDByName = make(map[string]string, len(msg.Transitions))
+		for i, t := range msg.Transitions {
+			items[i] = tuishell.ListPopoverItem{Label: t.Name, Value: t.Name}
+			m.transitionIDByName[t.Name] = t.ID
+		}
+		m.transitionPicker.Open(fmt.Sprintf("Transition %s", m.pendingTransition), items)
+		return m, func() tea.Msg { return tuishell.FinishTaskMsg{Err: nil} }
+
+	case tuishell.SelectListPopoverMsg:
+		if m.pendingTransition != "" {
+			issueKey := m.pendingTransition
+			transitionID := m.transitionIDByName[msg.Value]
+			m.pendingTransition = ""
+			m.transitionIDByName = nil
+			m.transitionPicker.Close()
+			return m, func() tea.Msg {
+				return tuishell.StartTaskMsg{Cmd: m.doTransition(issueKey, transitionID)}
+			}
+		}
+
+	case tuishell.CloseListPopoverMsg:
+		m.pendingTransition = ""
+		m.transitionIDByName = nil
+		m.transitionPicker.Close()
+
+	case TransitionDoneMsg:
+		if msg.Err != nil {
+			return m, func() tea.Msg {
+				return tuishell.FinishTaskMsg{Err: msg.Err}
+			}
+		}
+		var cmds []tea.Cmd
+		cmds = append(cmds, func() tea.Msg {
+			return tuishell.FinishTaskMsg{Err: nil, Keybinds: issues.Keybinds}
+		})
+		cmds = append(cmds, func() tea.Msg {
+			return tuishell.SetStatusMsg{Content: "✓ Transition complete"}
+		})
+		// Refetch issues if we have a selected board
+		if main, ok := m.Shell.Main.(issues.Model); ok && main.SelectedBoard != "" {
+			main.Loading = true
+			m.Shell.Main = main
+			cmds = append(cmds, func() tea.Msg {
+				return tuishell.StartTaskMsg{Cmd: m.fetchIssues(main.SelectedBoard)}
+			})
+		}
+		return m, tea.Batch(cmds...)
+
 	case tuishell.FinishTaskMsg:
 		if main, ok := m.Shell.Main.(issues.Model); ok {
 			main.Loading = false
 			m.Shell.Main = main
+		}
+	}
+
+	// Route keys to transition picker when open
+	if m.transitionPicker.IsOpen() {
+		if _, ok := msg.(tea.KeyPressMsg); ok {
+			var cmd tea.Cmd
+			m.transitionPicker, cmd = m.transitionPicker.Update(msg)
+			return m, cmd
 		}
 	}
 
@@ -120,13 +208,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) View() tea.View {
-	return m.Shell.RenderView()
+	v := m.Shell.RenderView()
+	if m.transitionPicker.IsOpen() {
+		w := m.Shell.Ctx.Window.Width
+		h := m.Shell.Ctx.Window.Height
+		screen := m.transitionPicker.View(v.Content, w, h)
+		return tea.View{Content: screen, AltScreen: v.AltScreen}
+	}
+	return v
 }
 
 func (m *Model) syncKeybinds() {
 	switch m.Shell.Ctx.FocusedPanel {
 	case tuishell.LeftPanel:
 		m.Shell.Statusline.Keybinds = boards.Keybinds
+	case tuishell.MainPanel:
+		m.Shell.Statusline.Keybinds = issues.Keybinds
 	default:
 		m.Shell.Statusline.Keybinds = tuishell.GlobalKeys(m.Shell.Ctx.DevMode)
 	}
@@ -136,5 +233,19 @@ func (m Model) fetchIssues(projectKey string) tea.Cmd {
 	return func() tea.Msg {
 		iss, err := m.client.GetMyIssues(projectKey)
 		return issues.FetchedMsg{Issues: iss, Err: err}
+	}
+}
+
+func (m Model) fetchTransitions(issueKey string) tea.Cmd {
+	return func() tea.Msg {
+		t, err := m.client.GetTransitions(issueKey)
+		return TransitionsFetchedMsg{Transitions: t, Err: err}
+	}
+}
+
+func (m Model) doTransition(issueKey, transitionID string) tea.Cmd {
+	return func() tea.Msg {
+		err := m.client.DoTransition(issueKey, transitionID)
+		return TransitionDoneMsg{Err: err}
 	}
 }

--- a/internal/tui/issues/issues.go
+++ b/internal/tui/issues/issues.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/felipeospina21/jiraf/internal/jira"
+	"github.com/felipeospina21/jiraf/internal/tui"
 	"github.com/felipeospina21/jiraf/internal/tui/icon"
 	"github.com/felipeospina21/tuishell"
 	"github.com/felipeospina21/tuishell/style"
@@ -37,6 +38,11 @@ type FetchedMsg struct {
 
 // ViewDetailsMsg is sent when the user wants to view issue details.
 type ViewDetailsMsg struct {
+	Issue jira.Issue
+}
+
+// TransitionMsg is sent when the user wants to transition an issue's status.
+type TransitionMsg struct {
 	Issue jira.Issue
 }
 
@@ -131,12 +137,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.KeyPressMsg:
-		switch msg.String() {
-		case "enter", "l":
+		match := tui.KeyMatcher(msg)
+		switch {
+		case match(Keybinds.Details):
 			idx := m.Table.Cursor()
 			if idx >= 0 && idx < len(m.Issues) {
 				issue := m.Issues[idx]
 				return m, func() tea.Msg { return ViewDetailsMsg{Issue: issue} }
+			}
+		case match(Keybinds.Transition):
+			idx := m.Table.Cursor()
+			if idx >= 0 && idx < len(m.Issues) {
+				issue := m.Issues[idx]
+				return m, func() tea.Msg { return TransitionMsg{Issue: issue} }
 			}
 		}
 		var cmd tea.Cmd

--- a/internal/tui/issues/keys.go
+++ b/internal/tui/issues/keys.go
@@ -1,0 +1,40 @@
+package issues
+
+import (
+	"slices"
+
+	"charm.land/bubbles/v2/key"
+	"github.com/felipeospina21/jiraf/internal/tui"
+)
+
+type IssuesKeyMap struct {
+	Details    key.Binding
+	Transition key.Binding
+	tui.GlobalKeyMap
+}
+
+func (k IssuesKeyMap) ShortHelp() []key.Binding {
+	return slices.Concat(
+		[]key.Binding{k.Details, k.Transition},
+		tui.CommonKeys,
+	)
+}
+
+func (k IssuesKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		tui.CommonKeys,
+		{k.Details, k.Transition},
+	}
+}
+
+var Keybinds = IssuesKeyMap{
+	Details: key.NewBinding(
+		key.WithKeys("enter", "l"),
+		key.WithHelp("enter", "details"),
+	),
+	Transition: key.NewBinding(
+		key.WithKeys("T"),
+		key.WithHelp("T", "transition"),
+	),
+	GlobalKeyMap: tui.GlobalKeys(false),
+}


### PR DESCRIPTION
## Summary

Add the ability to transition issue status (To Do → In Progress → Done) from the issues table.

## Changes

- **API layer**: Add `GetTransitions()` and `DoTransition()` methods to the Jira client, plus a `post()` HTTP helper
- **Issues panel**: Add `T` keybinding (capitalized, per mutation convention) that sends `TransitionMsg`
- **App**: Handle transition flow — fetch available transitions, show numbered list in confirmation modal, execute selected transition, refetch issues
- **Mock data**: Add `MockTransitions` with 4 statuses (To Do, In Progress, In Review, Done) for dev mode
- **Keybindings**: Add `IssuesKeyMap` with details and transition bindings, shown in statusline when main panel is focused

## Flow

1. User presses `T` on an issue → fetches available transitions (loading spinner)
2. Modal shows numbered list of transitions → user presses 1-9 to select (▸ marker)
3. User presses Enter to confirm → executes transition (loading spinner)
4. Issues refetch automatically after successful transition

## Testing

- Builds with `GOWORK=off go build ./...`
- Tests pass with `GOWORK=off go test ./...`
- Dev mode works with mock data (`-dev` flag)

Closes #8