### PR TITLE
feat: add confirmation popover before transition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.2
 	charm.land/glamour/v2 v2.0.0
 	charm.land/lipgloss/v2 v2.0.2
-	github.com/felipeospina21/tuishell v0.4.0
+	github.com/felipeospina21/tuishell v0.5.0
 	github.com/spf13/viper v1.21.0
 	golang.org/x/net v0.47.0
 )

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/felipeospina21/tuishell v0.4.0 h1:thl2CYw6wdN/PnbRYZFfTew+dTpIFBGemNfYYT203PE=
-github.com/felipeospina21/tuishell v0.4.0/go.mod h1:PdkAVJRM2ug1qKEuW+myzWJy0Q5sILUlU+gMN6sU/h0=
+github.com/felipeospina21/tuishell v0.5.0 h1:1PyRHMUPfOb6NFBp2CrCYBoPuGJSnI+oy9NyW1ztWoo=
+github.com/felipeospina21/tuishell v0.5.0/go.mod h1:PdkAVJRM2ug1qKEuW+myzWJy0Q5sILUlU+gMN6sU/h0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -39,9 +39,11 @@ type Model struct {
 	client  *jira.Client
 
 	// Transition state
-	pendingTransition  string // issue key awaiting transition
-	transitionPicker   popover.ListModel
-	transitionIDByName map[string]string
+	pendingTransition      string // issue key awaiting transition
+	pendingTransitionName  string // selected transition name awaiting confirmation
+	confirmPopover         popover.ConfirmModel
+	transitionPicker       popover.ListModel
+	transitionIDByName     map[string]string
 }
 
 func NewApp() tea.Model {
@@ -70,7 +72,13 @@ func NewApp() tea.Model {
 		RightPanelStyle: rightPanelStyle,
 	})
 
-	return Model{Shell: s, Details: &det, client: client, transitionPicker: popover.NewList(theme)}
+	return Model{
+		Shell:            s,
+		Details:          &det,
+		client:           client,
+		confirmPopover:   popover.NewConfirm(theme),
+		transitionPicker: popover.NewList(theme),
+	}
 }
 
 func (m Model) Init() tea.Cmd {
@@ -135,15 +143,32 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tuishell.SelectListPopoverMsg:
 		if m.pendingTransition != "" {
-			issueKey := m.pendingTransition
-			transitionID := m.transitionIDByName[msg.Value]
-			m.pendingTransition = ""
-			m.transitionIDByName = nil
+			m.pendingTransitionName = msg.Value
 			m.transitionPicker.Close()
-			return m, func() tea.Msg {
-				return tuishell.StartTaskMsg{Cmd: m.doTransition(issueKey, transitionID)}
-			}
+			m.confirmPopover.Open(
+				"Transition Issue",
+				fmt.Sprintf("Transition %s to %s?", m.pendingTransition, msg.Value),
+				"Confirm",
+				"Cancel",
+			)
 		}
+
+	case tuishell.ConfirmPopoverYesMsg:
+		m.confirmPopover.Close()
+		issueKey := m.pendingTransition
+		transitionID := m.transitionIDByName[m.pendingTransitionName]
+		m.pendingTransition = ""
+		m.pendingTransitionName = ""
+		m.transitionIDByName = nil
+		return m, func() tea.Msg {
+			return tuishell.StartTaskMsg{Cmd: m.doTransition(issueKey, transitionID)}
+		}
+
+	case tuishell.ConfirmPopoverNoMsg:
+		m.confirmPopover.Close()
+		m.pendingTransition = ""
+		m.pendingTransitionName = ""
+		m.transitionIDByName = nil
 
 	case tuishell.CloseListPopoverMsg:
 		m.pendingTransition = ""
@@ -180,6 +205,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// Route keys to confirm popover when open
+	if m.confirmPopover.IsOpen() {
+		if _, ok := msg.(tea.KeyPressMsg); ok {
+			var cmd tea.Cmd
+			m.confirmPopover, cmd = m.confirmPopover.Update(msg)
+			return m, cmd
+		}
+	}
+
 	// Route keys to transition picker when open
 	if m.transitionPicker.IsOpen() {
 		if _, ok := msg.(tea.KeyPressMsg); ok {
@@ -209,9 +243,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m Model) View() tea.View {
 	v := m.Shell.RenderView()
+	w := m.Shell.Ctx.Window.Width
+	h := m.Shell.Ctx.Window.Height
+	if m.confirmPopover.IsOpen() {
+		screen := m.confirmPopover.View(v.Content, w, h)
+		return tea.View{Content: screen, AltScreen: v.AltScreen}
+	}
 	if m.transitionPicker.IsOpen() {
-		w := m.Shell.Ctx.Window.Width
-		h := m.Shell.Ctx.Window.Height
 		screen := m.transitionPicker.View(v.Content, w, h)
 		return tea.View{Content: screen, AltScreen: v.AltScreen}
 	}


### PR DESCRIPTION
## Summary

Transition mutation now shows a confirmation popover after the user selects the target status.

## Flow

`T` → fetch transitions → pick status → confirm ("Transition ISSUE-123 to Done?") → execute

## Changes

- `app/app.go`: Added `confirmPopover` and `pendingTransitionName` fields. `SelectListPopoverMsg` now opens the confirm popover instead of executing immediately. Confirm/cancel handlers added.

## What was tested

- Build passes