### PR TITLE
feat: open issue in browser and refetch issues

### DIFF
--- a/internal/exec/openbrowser.go
+++ b/internal/exec/openbrowser.go
@@ -1,0 +1,24 @@
+package exec
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+// OpenBrowser opens the given URL in the default system browser.
+func OpenBrowser(url string) {
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	default:
+		return
+	}
+
+	_ = cmd.Start()
+}

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/felipeospina21/jiraf/internal/config"
+	jirafExec "github.com/felipeospina21/jiraf/internal/exec"
 	"github.com/felipeospina21/jiraf/internal/jira"
 	"github.com/felipeospina21/jiraf/internal/tui/boards"
 	"github.com/felipeospina21/jiraf/internal/tui/details"
@@ -118,6 +119,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, func() tea.Msg { return tuishell.OpenRightPanelMsg{} })
 		}
 		return m, tea.Batch(cmds...)
+
+	case issues.OpenInBrowserMsg:
+		url := config.GlobalConfig.BaseURL + "/browse/" + msg.IssueKey
+		jirafExec.OpenBrowser(url)
+		return m, nil
+
+	case issues.RefetchMsg:
+		if main, ok := m.Shell.Main.(issues.Model); ok && main.SelectedBoard != "" {
+			main.Loading = true
+			main.SpinnerView = m.Shell.Spinner.View()
+			m.Shell.Main = main
+			return m, func() tea.Msg {
+				return tuishell.StartTaskMsg{Cmd: m.fetchIssues(main.SelectedBoard)}
+			}
+		}
 
 	case issues.TransitionMsg:
 		m.pendingTransition = msg.Issue.Key

--- a/internal/tui/issues/issues.go
+++ b/internal/tui/issues/issues.go
@@ -46,6 +46,14 @@ type TransitionMsg struct {
 	Issue jira.Issue
 }
 
+// OpenInBrowserMsg is sent when the user wants to open the issue in the browser.
+type OpenInBrowserMsg struct {
+	IssueKey string
+}
+
+// RefetchMsg is sent when the user wants to refetch the issues list.
+type RefetchMsg struct{}
+
 var cols = []table.Column{
 	{Name: "created", Title: icon.Clock, Width: 3},
 	{Name: "priority", Title: "Priority", Width: 4, Centered: true},
@@ -151,6 +159,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				issue := m.Issues[idx]
 				return m, func() tea.Msg { return TransitionMsg{Issue: issue} }
 			}
+		case match(Keybinds.OpenInBrowser):
+			idx := m.Table.Cursor()
+			if idx >= 0 && idx < len(m.Issues) {
+				issueKey := m.Issues[idx].Key
+				return m, func() tea.Msg { return OpenInBrowserMsg{IssueKey: issueKey} }
+			}
+		case match(Keybinds.Refetch):
+			return m, func() tea.Msg { return RefetchMsg{} }
 		}
 		var cmd tea.Cmd
 		m.Table, cmd = m.Table.Update(msg)

--- a/internal/tui/issues/keys.go
+++ b/internal/tui/issues/keys.go
@@ -8,14 +8,16 @@ import (
 )
 
 type IssuesKeyMap struct {
-	Details    key.Binding
-	Transition key.Binding
+	Details       key.Binding
+	OpenInBrowser key.Binding
+	Transition    key.Binding
+	Refetch       key.Binding
 	tui.GlobalKeyMap
 }
 
 func (k IssuesKeyMap) ShortHelp() []key.Binding {
 	return slices.Concat(
-		[]key.Binding{k.Details, k.Transition},
+		[]key.Binding{k.Details, k.OpenInBrowser, k.Transition, k.Refetch},
 		tui.CommonKeys,
 	)
 }
@@ -23,7 +25,7 @@ func (k IssuesKeyMap) ShortHelp() []key.Binding {
 func (k IssuesKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		tui.CommonKeys,
-		{k.Details, k.Transition},
+		{k.Details, k.OpenInBrowser, k.Transition, k.Refetch},
 	}
 }
 
@@ -32,9 +34,17 @@ var Keybinds = IssuesKeyMap{
 		key.WithKeys("enter", "l"),
 		key.WithHelp("enter", "details"),
 	),
+	OpenInBrowser: key.NewBinding(
+		key.WithKeys("x"),
+		key.WithHelp("x", "open in browser"),
+	),
 	Transition: key.NewBinding(
 		key.WithKeys("T"),
 		key.WithHelp("T", "transition"),
+	),
+	Refetch: key.NewBinding(
+		key.WithKeys("r"),
+		key.WithHelp("r", "refetch"),
 	),
 	GlobalKeyMap: tui.GlobalKeys(false),
 }


### PR DESCRIPTION
## Changes

- **Open in browser** (`x`): Opens the selected Jira issue in the default browser using `base_url/browse/{issueKey}`
- **Refetch issues** (`r`): Re-fetches the issues list for the currently selected board

Both keybindings are shown in the statusline help.

## New files

- `internal/exec/openbrowser.go` — cross-platform browser opener

## Modified files

- `internal/tui/issues/keys.go` — added `OpenInBrowser` and `Refetch` key bindings
- `internal/tui/issues/issues.go` — added handlers for both keybindings
- `internal/tui/app/app.go` — added app-level message handling for `OpenInBrowserMsg` and `RefetchMsg`

Closes #7
Closes #16