### PR TITLE
fix: handle fullscreen toggle in details panel

### DIFF
--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -260,10 +260,10 @@ func (m *Model) syncKeybinds() {
 	switch m.Shell.Ctx.FocusedPanel {
 	case tuishell.LeftPanel:
 		m.Shell.Statusline.Keybinds = boards.Keybinds
+	case tuishell.RightPanel:
+		m.Shell.Statusline.Keybinds = details.Keybinds
 	case tuishell.MainPanel:
 		m.Shell.Statusline.Keybinds = issues.Keybinds
-	default:
-		m.Shell.Statusline.Keybinds = tuishell.GlobalKeys(m.Shell.Ctx.DevMode)
 	}
 }
 

--- a/internal/tui/details/details.go
+++ b/internal/tui/details/details.go
@@ -11,6 +11,8 @@ import (
 	"charm.land/glamour/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/felipeospina21/jiraf/internal/jira"
+	"github.com/felipeospina21/jiraf/internal/tui"
+	"github.com/felipeospina21/tuishell"
 	"github.com/felipeospina21/tuishell/style"
 )
 
@@ -36,6 +38,12 @@ func (m Model) Init() tea.Cmd { return nil }
 
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		match := tui.KeyMatcher(msg)
+		switch {
+		case match(Keybinds.Fullscreen):
+			return m, func() tea.Msg { return tuishell.ToggleFullscreenMsg{} }
+		}
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height

--- a/internal/tui/details/keys.go
+++ b/internal/tui/details/keys.go
@@ -1,0 +1,35 @@
+package details
+
+import (
+	"slices"
+
+	"charm.land/bubbles/v2/key"
+	"github.com/felipeospina21/jiraf/internal/tui"
+)
+
+type DetailsKeyMap struct {
+	Fullscreen key.Binding
+	tui.GlobalKeyMap
+}
+
+func (k DetailsKeyMap) ShortHelp() []key.Binding {
+	return slices.Concat(
+		[]key.Binding{k.Fullscreen},
+		tui.CommonKeys,
+	)
+}
+
+func (k DetailsKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		tui.CommonKeys,
+		{k.Fullscreen},
+	}
+}
+
+var Keybinds = DetailsKeyMap{
+	Fullscreen: key.NewBinding(
+		key.WithKeys("f"),
+		key.WithHelp("f", "fullscreen"),
+	),
+	GlobalKeyMap: tui.GlobalKeys(false),
+}


### PR DESCRIPTION
## Changes

- Added `Fullscreen` keybinding (`f`) to new `DetailsKeyMap` in `internal/tui/details/keys.go`
- Details component handles `f` and emits `tuishell.ToggleFullscreenMsg{}`
- Fixed `syncKeybinds` to show `details.Keybinds` when right panel is focused (was falling through to global keys)

## Why

Fullscreen toggle was removed from tuishell's global keys (felipeospina21/tuishell#16). The right panel now owns the `f` keybinding, and the statusline correctly shows it.

Depends on felipeospina21/tuishell#16