### PR TITLE
feat: custom theme colors via config with presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,15 @@ You can customize the color theme by adding a `[theme]` section to your config f
 
 **Presets:** Use a preconfigured palette by name. Individual overrides can be combined with a preset.
 
-| Preset             | Description                  |
-| ------------------ | ---------------------------- |
-| `catppuccin-mocha` | Catppuccin Mocha (dark)      |
+| Preset                 | Description                  |
+| ---------------------- | ---------------------------- |
+| `catppuccin-mocha`     | Catppuccin Mocha (dark)      |
+| `catppuccin-macchiato` | Catppuccin Macchiato         |
+| `catppuccin-frappe`    | Catppuccin Frappé            |
+| `catppuccin-latte`     | Catppuccin Latte (light)     |
+| `rose-pine`            | Rosé Pine                    |
+| `tokyo-night`          | Tokyo Night                  |
+| `dracula`              | Dracula                      |
 
 ```toml
 [theme]

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ export JIRAF_TOKEN="YOUR_JIRA_API_TOKEN"
 | Option           | Description           | Default | Required |
 | ---------------- | --------------------- | ------- | -------- |
 | `base_url`       | Jira instance URL     | —       | Yes      |
-| `filters.boards` | List of board objects | —       | Yes      |
+| `filters.boards` | List of board objects  | —       | Yes      |
+| `theme`          | Color overrides (see [Theme](#theme)) | Jira blue | No |
 
 ### Board object
 
@@ -110,6 +111,42 @@ Each board in `filters.boards` has the following fields:
 | `id`   | `string` | Jira board ID                        |
 | `key`  | `string` | Jira project key (e.g. `PROJ`)       |
 
+### Theme
+
+You can customize the color theme by adding a `[theme]` section to your config file. Each property accepts a hex color string. Only the tokens you specify are overridden — everything else falls back to the default Jira blue palette.
+
+| Token             | Description                        | Default   |
+| ----------------- | ---------------------------------- | --------- |
+| `primary`         | Primary accent color               | `#2684FF` |
+| `primary_bright`  | Brighter primary variant           | `#0065FF` |
+| `primary_fg`      | Foreground on primary backgrounds  | `#DEEBFF` |
+| `primary_dim`     | Dimmed primary for subtle accents  | `#002B6B` |
+| `info`            | Informational color                | `#4C9AFF` |
+| `info_bright`     | Brighter info variant              | `#2684FF` |
+| `success`         | Success / positive state           | `#6beaaf` |
+| `success_bright`  | Brighter success variant           | `#3ad994` |
+| `danger`          | Error / destructive state          | `#f9a8a8` |
+| `danger_bright`   | Brighter danger variant            | `#f47575` |
+| `warning`         | Warning state                      | `#ffe043` |
+| `warning_bright`  | Brighter warning variant           | `#ffcc14` |
+| `caution`         | Caution / attention state          | `#ff8237` |
+| `text`            | Default text color                 | `#C4C4C4` |
+| `text_inverse`    | Text on light backgrounds          | `#111`    |
+| `text_dimmed`     | Dimmed / secondary text            | `#777777` |
+| `muted`           | Muted text                         | `#999999` |
+| `dim`             | Dimmed UI elements                 | `#444444` |
+| `border`          | Panel borders                      | `#3f4145` |
+| `modal_border`    | Modal overlay border               | `#666666` |
+| `surface_dim`     | Dark surface background            | `#091E42` |
+| `selection_border`| Selected item border               | `#0052CC` |
+| `status_text`     | Status bar text                    | `#FFFDF5` |
+| `status_normal`   | Status bar normal mode             | `#0747A6` |
+| `status_loading`  | Status bar loading state           | `#1A7A94` |
+| `status_error`    | Status bar error state             | `#CE3060` |
+| `status_dev`      | Status bar dev mode indicator      | `#4E8212` |
+| `status_accent1`  | Status bar accent 1                | `#0065FF` |
+| `status_accent2`  | Status bar accent 2                | `#003884` |
+
 ### Config example
 
 ```toml
@@ -120,6 +157,12 @@ boards = [
     { name = "Some Board", id = "3588", key = "SMB" },
     { name = "Platform Sprint", id = "42", key = "PLAT" },
 ]
+
+# Optional: override specific theme colors
+[theme]
+primary = "#0052CC"
+success = "#22C55E"
+danger = "#EF4444"
 ```
 
 ## Related

--- a/README.md
+++ b/README.md
@@ -113,7 +113,20 @@ Each board in `filters.boards` has the following fields:
 
 ### Theme
 
-You can customize the color theme by adding a `[theme]` section to your config file. Each property accepts a hex color string. Only the tokens you specify are overridden — everything else falls back to the default Jira blue palette.
+You can customize the color theme by adding a `[theme]` section to your config file.
+
+**Presets:** Use a preconfigured palette by name. Individual overrides can be combined with a preset.
+
+| Preset             | Description                  |
+| ------------------ | ---------------------------- |
+| `catppuccin-mocha` | Catppuccin Mocha (dark)      |
+
+```toml
+[theme]
+preset = "catppuccin-mocha"
+```
+
+**Individual overrides:** Each property accepts a hex color string. Only the tokens you specify are overridden — everything else falls back to the preset (or the default Jira blue palette if no preset is set).
 
 | Token             | Description                        | Default   |
 | ----------------- | ---------------------------------- | --------- |
@@ -158,11 +171,14 @@ boards = [
     { name = "Platform Sprint", id = "42", key = "PLAT" },
 ]
 
-# Optional: override specific theme colors
+# Optional: use a preset theme
 [theme]
-primary = "#0052CC"
-success = "#22C55E"
-danger = "#EF4444"
+preset = "catppuccin-mocha"
+
+# Or override specific colors (works with or without a preset)
+# primary = "#0052CC"
+# success = "#22C55E"
+# danger = "#EF4444"
 ```
 
 ## Related

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,19 +8,18 @@ _(none)_
 
 ### Critical
 
-- [ ] Assign/unassign issue ([#6](https://github.com/felipeospina21/jiraf/issues/6))
 - [ ] Add comment ([#5](https://github.com/felipeospina21/jiraf/issues/5))
+- [ ] View comments in details panel ([#12](https://github.com/felipeospina21/jiraf/issues/12))
 
 ### High
 
-- [ ] View comments in details panel ([#12](https://github.com/felipeospina21/jiraf/issues/12))
 - [ ] View subtasks in details panel ([#9](https://github.com/felipeospina21/jiraf/issues/9))
-- [ ] Markdown/ADF rendering in details ([#11](https://github.com/felipeospina21/jiraf/issues/11))
 - [ ] Filter issues (client-side by status, type, priority, label) ([#10](https://github.com/felipeospina21/jiraf/issues/10))
 - [ ] Sort issues (by column) ([#13](https://github.com/felipeospina21/jiraf/issues/13))
 - [ ] Pagination / load more ([#15](https://github.com/felipeospina21/jiraf/issues/15))
 - [ ] Sprint board view (kanban columns) ([#17](https://github.com/felipeospina21/jiraf/issues/17))
 - [ ] Create issue ([#14](https://github.com/felipeospina21/jiraf/issues/14))
+- [ ] Assign/unassign issue ([#6](https://github.com/felipeospina21/jiraf/issues/6))
 
 ### Medium
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,6 +23,7 @@ _(none)_
 
 ### Medium
 
+- [ ] In-app theme selector with live preview and config persistence ([#31](https://github.com/felipeospina21/jiraf/issues/31))
 - [ ] API response caching with configurable TTL ([#23](https://github.com/felipeospina21/jiraf/issues/23))
 - [ ] Custom theme colors via config ([#24](https://github.com/felipeospina21/jiraf/issues/24))
 - [ ] Edit issue (summary, description, priority, labels) ([#21](https://github.com/felipeospina21/jiraf/issues/21))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type Filter struct {
 // ThemeOverrides holds optional color overrides for the theme.
 // Each field is a hex color string (e.g. "#FF5733"). Nil means use default.
 type ThemeOverrides struct {
+	Preset          *string `mapstructure:"preset"`
 	Primary         *string `mapstructure:"primary"`
 	PrimaryBright   *string `mapstructure:"primary_bright"`
 	PrimaryFg       *string `mapstructure:"primary_fg"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,11 +21,46 @@ type Filter struct {
 	Boards []Board `mapstructure:"boards"`
 }
 
+// ThemeOverrides holds optional color overrides for the theme.
+// Each field is a hex color string (e.g. "#FF5733"). Nil means use default.
+type ThemeOverrides struct {
+	Primary         *string `mapstructure:"primary"`
+	PrimaryBright   *string `mapstructure:"primary_bright"`
+	PrimaryFg       *string `mapstructure:"primary_fg"`
+	PrimaryDim      *string `mapstructure:"primary_dim"`
+	Info            *string `mapstructure:"info"`
+	InfoBright      *string `mapstructure:"info_bright"`
+	Success         *string `mapstructure:"success"`
+	SuccessBright   *string `mapstructure:"success_bright"`
+	Danger          *string `mapstructure:"danger"`
+	DangerBright    *string `mapstructure:"danger_bright"`
+	Warning         *string `mapstructure:"warning"`
+	WarningBright   *string `mapstructure:"warning_bright"`
+	Caution         *string `mapstructure:"caution"`
+	Text            *string `mapstructure:"text"`
+	TextInverse     *string `mapstructure:"text_inverse"`
+	TextDimmed      *string `mapstructure:"text_dimmed"`
+	Muted           *string `mapstructure:"muted"`
+	Dim             *string `mapstructure:"dim"`
+	Border          *string `mapstructure:"border"`
+	ModalBorder     *string `mapstructure:"modal_border"`
+	SurfaceDim      *string `mapstructure:"surface_dim"`
+	SelectionBorder *string `mapstructure:"selection_border"`
+	StatusText      *string `mapstructure:"status_text"`
+	StatusNormal    *string `mapstructure:"status_normal"`
+	StatusLoading   *string `mapstructure:"status_loading"`
+	StatusError     *string `mapstructure:"status_error"`
+	StatusDev       *string `mapstructure:"status_dev"`
+	StatusAccent1   *string `mapstructure:"status_accent1"`
+	StatusAccent2   *string `mapstructure:"status_accent2"`
+}
+
 // Config holds the application configuration.
 type Config struct {
-	BaseURL  string `mapstructure:"base_url"`
+	BaseURL  string         `mapstructure:"base_url"`
 	APIToken string
-	Filters  Filter `mapstructure:"filters"`
+	Filters  Filter         `mapstructure:"filters"`
+	Theme    ThemeOverrides `mapstructure:"theme"`
 	DevMode  bool
 }
 

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/felipeospina21/jiraf/internal/config"
 	jirafExec "github.com/felipeospina21/jiraf/internal/exec"
 	"github.com/felipeospina21/jiraf/internal/jira"
+	"github.com/felipeospina21/jiraf/internal/tui"
 	"github.com/felipeospina21/jiraf/internal/tui/boards"
 	"github.com/felipeospina21/jiraf/internal/tui/details"
 	"github.com/felipeospina21/jiraf/internal/tui/icon"
@@ -16,10 +17,9 @@ import (
 	"github.com/felipeospina21/tuishell"
 	"github.com/felipeospina21/tuishell/popover"
 	"github.com/felipeospina21/tuishell/shell"
-	"github.com/felipeospina21/tuishell/style"
 )
 
-var theme = style.DefaultTheme()
+var theme = tui.DefaultTheme()
 
 var leftPanelStyle = lipgloss.NewStyle().
 	PaddingRight(4).

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -19,20 +19,6 @@ import (
 	"github.com/felipeospina21/tuishell/shell"
 )
 
-var theme = tui.DefaultTheme()
-
-var leftPanelStyle = lipgloss.NewStyle().
-	PaddingRight(4).
-	MarginBottom(2).
-	Foreground(theme.Primary).
-	Border(lipgloss.NormalBorder(), false, true, false, false).
-	BorderForeground(theme.Border).
-	Width(30)
-
-var rightPanelStyle = lipgloss.NewStyle().
-	Border(lipgloss.NormalBorder(), true, false, true, true).
-	BorderForeground(theme.Border)
-
 // Model wraps shell.Model with jiraf-specific domain logic.
 type Model struct {
 	Shell   shell.Model
@@ -54,11 +40,25 @@ func NewApp() tea.Model {
 		os.Exit(1)
 	}
 
+	theme := tui.BuildTheme(cfg.Theme)
+
+	leftPanelStyle := lipgloss.NewStyle().
+		PaddingRight(4).
+		MarginBottom(2).
+		Foreground(theme.Primary).
+		Border(lipgloss.NormalBorder(), false, true, false, false).
+		BorderForeground(theme.Border).
+		Width(30)
+
+	rightPanelStyle := lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder(), true, false, true, true).
+		BorderForeground(theme.Border)
+
 	client := jira.NewClient(cfg)
-	b := boards.New(cfg.Filters.Boards)
+	b := boards.New(cfg.Filters.Boards, theme)
 	left := BoardsPanel{Model: &b}
-	main := issues.New()
-	det := details.New()
+	main := issues.New(theme)
+	det := details.New(theme)
 
 	s := shell.New(shell.Config{
 		Theme:           theme,

--- a/internal/tui/boards/boards.go
+++ b/internal/tui/boards/boards.go
@@ -3,8 +3,10 @@ package boards
 import (
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/felipeospina21/jiraf/internal/config"
 	"github.com/felipeospina21/tuishell"
+	"github.com/felipeospina21/tuishell/style"
 )
 
 // SelectBoardMsg is sent when the user picks a board.
@@ -26,15 +28,15 @@ type Model struct {
 }
 
 // New creates a boards panel from config.
-func New(boards []config.Board) Model {
+func New(boards []config.Board, t style.Theme) Model {
 	items := make([]list.Item, len(boards))
 	for i, b := range boards {
 		items[i] = item{board: b}
 	}
-	l := list.New(items, itemDelegate{ShowDescription: true, Styles: NewDefaultItemStyles()}, 30, 10)
+	l := list.New(items, itemDelegate{ShowDescription: true, Styles: NewDefaultItemStyles(t)}, 30, 10)
 	tuishell.ConfigureList(&l)
 	l.Title = "Boards"
-	l.Styles.Title = TitleStyle
+	l.Styles.Title = lipgloss.NewStyle().Foreground(t.Info)
 	l.SetShowHelp(false)
 	return Model{List: l}
 }

--- a/internal/tui/boards/boards.go
+++ b/internal/tui/boards/boards.go
@@ -31,9 +31,10 @@ func New(boards []config.Board) Model {
 	for i, b := range boards {
 		items[i] = item{board: b}
 	}
-	l := list.New(items, list.NewDefaultDelegate(), 30, 10)
+	l := list.New(items, itemDelegate{ShowDescription: true, Styles: NewDefaultItemStyles()}, 30, 10)
 	tuishell.ConfigureList(&l)
 	l.Title = "Boards"
+	l.Styles.Title = TitleStyle
 	l.SetShowHelp(false)
 	return Model{List: l}
 }

--- a/internal/tui/boards/styles.go
+++ b/internal/tui/boards/styles.go
@@ -1,0 +1,134 @@
+package boards
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"charm.land/bubbles/v2/list"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/felipeospina21/jiraf/internal/tui"
+)
+
+const ellipsis = "…"
+
+var theme = tui.DefaultTheme()
+
+var TitleStyle = lipgloss.NewStyle().
+	Foreground(theme.Info)
+
+type DefaultItemStyles struct {
+	NormalTitle    lipgloss.Style
+	NormalDesc     lipgloss.Style
+	SelectedTitle  lipgloss.Style
+	SelectedDesc   lipgloss.Style
+	DimmedTitle    lipgloss.Style
+	DimmedDesc     lipgloss.Style
+	FilterMatch    lipgloss.Style
+}
+
+func NewDefaultItemStyles() (s DefaultItemStyles) {
+	s.NormalTitle = lipgloss.NewStyle().
+		Foreground(theme.PrimaryFg).
+		Padding(0, 0, 0, 2)
+
+	s.NormalDesc = lipgloss.NewStyle().
+		Foreground(theme.TextDimmed).
+		Padding(0, 0, 0, 2)
+
+	s.SelectedTitle = lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder(), false, false, false, true).
+		BorderForeground(theme.SelectionBorder).
+		Foreground(theme.PrimaryBright).
+		Padding(0, 0, 0, 1)
+
+	s.SelectedDesc = s.SelectedTitle.
+		Foreground(theme.PrimaryBright)
+
+	s.DimmedTitle = lipgloss.NewStyle().
+		Foreground(theme.TextDimmed).
+		Padding(0, 0, 0, 2)
+
+	s.DimmedDesc = lipgloss.NewStyle().
+		Foreground(theme.Dim)
+
+	s.FilterMatch = lipgloss.NewStyle().Underline(true)
+
+	return s
+}
+
+type itemDelegate struct {
+	ShowDescription bool
+	Styles          DefaultItemStyles
+}
+
+func (d itemDelegate) Height() int                             { return 2 }
+func (d itemDelegate) Spacing() int                            { return 0 }
+func (d itemDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	var (
+		title, desc  string
+		matchedRunes []int
+		s            = &d.Styles
+	)
+
+	if i, ok := listItem.(item); ok {
+		title = i.Title()
+		desc = i.Description()
+	} else {
+		return
+	}
+
+	if m.Width() <= 0 {
+		return
+	}
+
+	textwidth := m.Width() - s.NormalTitle.GetPaddingLeft() - s.NormalTitle.GetPaddingRight()
+	title = ansi.Truncate(title, textwidth, ellipsis)
+	if d.ShowDescription {
+		var lines []string
+		for i, line := range strings.Split(desc, "\n") {
+			if i >= d.Height()-1 {
+				break
+			}
+			lines = append(lines, ansi.Truncate(line, textwidth, ellipsis))
+		}
+		desc = strings.Join(lines, "\n")
+	}
+
+	var (
+		isSelected  = index == m.Index()
+		emptyFilter = m.FilterState() == list.Filtering && m.FilterValue() == ""
+		isFiltered  = m.FilterState() == list.Filtering || m.FilterState() == list.FilterApplied
+	)
+
+	if emptyFilter {
+		title = s.DimmedTitle.Render(title)
+		desc = s.DimmedDesc.Render(desc)
+	} else if isSelected && m.FilterState() != list.Filtering {
+		if isFiltered {
+			unmatched := s.SelectedTitle.Inline(true)
+			matched := unmatched.Inherit(s.FilterMatch)
+			title = lipgloss.StyleRunes(title, matchedRunes, matched, unmatched)
+		}
+		title = s.SelectedTitle.Render(title)
+		desc = s.SelectedDesc.Render(desc)
+	} else {
+		if isFiltered {
+			unmatched := s.NormalTitle.Inline(true)
+			matched := unmatched.Inherit(s.FilterMatch)
+			title = lipgloss.StyleRunes(title, matchedRunes, matched, unmatched)
+		}
+		title = s.NormalTitle.Render(title)
+		desc = s.NormalDesc.Render(desc)
+	}
+
+	if d.ShowDescription {
+		fmt.Fprintf(w, "%s\n%s", title, desc) //nolint: errcheck
+		return
+	}
+	fmt.Fprintf(w, "%s", title) //nolint: errcheck
+}

--- a/internal/tui/boards/styles.go
+++ b/internal/tui/boards/styles.go
@@ -9,15 +9,10 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
-	"github.com/felipeospina21/jiraf/internal/tui"
+	"github.com/felipeospina21/tuishell/style"
 )
 
 const ellipsis = "…"
-
-var theme = tui.DefaultTheme()
-
-var TitleStyle = lipgloss.NewStyle().
-	Foreground(theme.Info)
 
 type DefaultItemStyles struct {
 	NormalTitle    lipgloss.Style
@@ -29,30 +24,30 @@ type DefaultItemStyles struct {
 	FilterMatch    lipgloss.Style
 }
 
-func NewDefaultItemStyles() (s DefaultItemStyles) {
+func NewDefaultItemStyles(t style.Theme) (s DefaultItemStyles) {
 	s.NormalTitle = lipgloss.NewStyle().
-		Foreground(theme.PrimaryFg).
+		Foreground(t.PrimaryFg).
 		Padding(0, 0, 0, 2)
 
 	s.NormalDesc = lipgloss.NewStyle().
-		Foreground(theme.TextDimmed).
+		Foreground(t.TextDimmed).
 		Padding(0, 0, 0, 2)
 
 	s.SelectedTitle = lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder(), false, false, false, true).
-		BorderForeground(theme.SelectionBorder).
-		Foreground(theme.PrimaryBright).
+		BorderForeground(t.SelectionBorder).
+		Foreground(t.PrimaryBright).
 		Padding(0, 0, 0, 1)
 
 	s.SelectedDesc = s.SelectedTitle.
-		Foreground(theme.PrimaryBright)
+		Foreground(t.PrimaryBright)
 
 	s.DimmedTitle = lipgloss.NewStyle().
-		Foreground(theme.TextDimmed).
+		Foreground(t.TextDimmed).
 		Padding(0, 0, 0, 2)
 
 	s.DimmedDesc = lipgloss.NewStyle().
-		Foreground(theme.Dim)
+		Foreground(t.Dim)
 
 	s.FilterMatch = lipgloss.NewStyle().Underline(true)
 

--- a/internal/tui/details/details.go
+++ b/internal/tui/details/details.go
@@ -13,10 +13,9 @@ import (
 	"github.com/felipeospina21/jiraf/internal/jira"
 	"github.com/felipeospina21/jiraf/internal/tui"
 	"github.com/felipeospina21/tuishell"
-	"github.com/felipeospina21/tuishell/style"
 )
 
-var theme = style.DefaultTheme()
+var theme = tui.DefaultTheme()
 
 // Model holds the state for the details side panel.
 type Model struct {

--- a/internal/tui/details/details.go
+++ b/internal/tui/details/details.go
@@ -11,11 +11,9 @@ import (
 	"charm.land/glamour/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/felipeospina21/jiraf/internal/jira"
-	"github.com/felipeospina21/jiraf/internal/tui"
 	"github.com/felipeospina21/tuishell"
+	"github.com/felipeospina21/tuishell/style"
 )
-
-var theme = tui.DefaultTheme()
 
 // Model holds the state for the details side panel.
 type Model struct {
@@ -24,12 +22,23 @@ type Model struct {
 	issue    *jira.Issue
 	width    int
 	height   int
+	// theme-derived styles
+	keyStyle     lipgloss.Style
+	summaryStyle lipgloss.Style
+	labelStyle   lipgloss.Style
+	valueStyle   lipgloss.Style
+	sectionStyle lipgloss.Style
 }
 
 // New creates a new details panel model.
-func New() Model {
+func New(t style.Theme) Model {
 	return Model{
-		Viewport: viewport.New(viewport.WithWidth(10), viewport.WithHeight(10)),
+		Viewport:     viewport.New(viewport.WithWidth(10), viewport.WithHeight(10)),
+		keyStyle:     lipgloss.NewStyle().Foreground(t.Primary).Bold(true).MarginLeft(1),
+		summaryStyle: lipgloss.NewStyle().Foreground(t.Text).Bold(true).MarginLeft(1),
+		labelStyle:   lipgloss.NewStyle().Foreground(t.TextDimmed).MarginLeft(1).Width(14),
+		valueStyle:   lipgloss.NewStyle().Foreground(t.Text),
+		sectionStyle: lipgloss.NewStyle().Foreground(t.Primary).Bold(true).MarginLeft(1),
 	}
 }
 
@@ -38,7 +47,7 @@ func (m Model) Init() tea.Cmd { return nil }
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
-		match := tui.KeyMatcher(msg)
+		match := tuishell.KeyMatcher(msg)
 		switch {
 		case match(Keybinds.Fullscreen):
 			return m, func() tea.Msg { return tuishell.ToggleFullscreenMsg{} }
@@ -97,39 +106,39 @@ func (m *Model) renderContent() {
 	var b strings.Builder
 
 	// Key + Summary
-	b.WriteString(keyStyle.Render(m.issue.Key))
+	b.WriteString(m.keyStyle.Render(m.issue.Key))
 	b.WriteString("\n")
-	b.WriteString(summaryStyle.Render(f.Summary))
+	b.WriteString(m.summaryStyle.Render(f.Summary))
 	b.WriteString("\n\n")
 
 	// Status / Priority / Type
-	writeField(&b, "Status", f.Status.Name)
-	writeField(&b, "Priority", f.Priority.Name)
-	writeField(&b, "Type", f.IssueType.Name)
+	m.writeField(&b, "Status", f.Status.Name)
+	m.writeField(&b, "Priority", f.Priority.Name)
+	m.writeField(&b, "Type", f.IssueType.Name)
 	b.WriteString("\n")
 
 	// People
 	if f.Assignee != nil {
-		writeField(&b, "Assignee", f.Assignee.DisplayName)
+		m.writeField(&b, "Assignee", f.Assignee.DisplayName)
 	}
 	if f.Reporter != nil {
-		writeField(&b, "Reporter", f.Reporter.DisplayName)
+		m.writeField(&b, "Reporter", f.Reporter.DisplayName)
 	}
 	b.WriteString("\n")
 
 	// Sprint
 	if s := f.ActiveSprint(); s != nil {
-		writeField(&b, "Sprint", s.Name)
+		m.writeField(&b, "Sprint", s.Name)
 	}
 
 	// Story Points
 	if f.StoryPoints != nil {
-		writeField(&b, "Story Points", strconv.Itoa(int(*f.StoryPoints)))
+		m.writeField(&b, "Story Points", strconv.Itoa(int(*f.StoryPoints)))
 	}
 
 	// Labels
 	if len(f.Labels) > 0 {
-		writeField(&b, "Labels", strings.Join(f.Labels, ", "))
+		m.writeField(&b, "Labels", strings.Join(f.Labels, ", "))
 	}
 
 	// Components
@@ -138,20 +147,20 @@ func (m *Model) renderContent() {
 		for i, c := range f.Components {
 			names[i] = c.Name
 		}
-		writeField(&b, "Components", strings.Join(names, ", "))
+		m.writeField(&b, "Components", strings.Join(names, ", "))
 	}
 
 	// Comments
-	writeField(&b, "Comments", strconv.Itoa(f.Comment.Total))
+	m.writeField(&b, "Comments", strconv.Itoa(f.Comment.Total))
 
 	// Dates
-	writeField(&b, "Created", f.Created.Time.Format("2006-01-02 15:04"))
-	writeField(&b, "Updated", f.Updated.Time.Format("2006-01-02 15:04"))
+	m.writeField(&b, "Created", f.Created.Time.Format("2006-01-02 15:04"))
+	m.writeField(&b, "Updated", f.Updated.Time.Format("2006-01-02 15:04"))
 
 	// Description
 	if f.Description != "" || m.issue.RenderedFields.Description != "" {
 		b.WriteString("\n")
-		b.WriteString(sectionStyle.Render("Description"))
+		b.WriteString(m.sectionStyle.Render("Description"))
 		b.WriteString("\n")
 		desc := m.issue.RenderedFields.Description
 		if desc == "" {
@@ -165,8 +174,8 @@ func (m *Model) renderContent() {
 	m.Viewport.SetContent(b.String())
 }
 
-func writeField(b *strings.Builder, label, value string) {
-	b.WriteString(labelStyle.Render(label+":") + " " + valueStyle.Render(value) + "\n")
+func (m *Model) writeField(b *strings.Builder, label, value string) {
+	b.WriteString(m.labelStyle.Render(label+":") + " " + m.valueStyle.Render(value) + "\n")
 }
 
 func renderMarkdown(md string, width int) string {
@@ -184,7 +193,7 @@ func renderMarkdown(md string, width int) string {
 	return strings.TrimSpace(out)
 }
 
-// Styles
+// Styles that don't depend on theme
 var (
 	titleStyle = func() lipgloss.Style {
 		b := lipgloss.RoundedBorder()
@@ -197,10 +206,4 @@ var (
 		b.Left = "┤"
 		return lipgloss.NewStyle().BorderStyle(b).Padding(0)
 	}()
-
-	keyStyle     = lipgloss.NewStyle().Foreground(theme.Primary).Bold(true).MarginLeft(1)
-	summaryStyle = lipgloss.NewStyle().Foreground(theme.Text).Bold(true).MarginLeft(1)
-	labelStyle   = lipgloss.NewStyle().Foreground(theme.TextDimmed).MarginLeft(1).Width(14)
-	valueStyle   = lipgloss.NewStyle().Foreground(theme.Text)
-	sectionStyle = lipgloss.NewStyle().Foreground(theme.Primary).Bold(true).MarginLeft(1)
 )

--- a/internal/tui/issues/issues.go
+++ b/internal/tui/issues/issues.go
@@ -7,15 +7,13 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 	"github.com/felipeospina21/jiraf/internal/jira"
 	"github.com/felipeospina21/jiraf/internal/tui"
 	"github.com/felipeospina21/jiraf/internal/tui/icon"
 	"github.com/felipeospina21/tuishell"
+	"github.com/felipeospina21/tuishell/style"
 	"github.com/felipeospina21/tuishell/table"
 )
-
-var theme = tui.DefaultTheme()
 
 const (
 	tableBorderX  = 2
@@ -23,11 +21,6 @@ const (
 	headerLines   = 1
 	tableOverhead = 1
 )
-
-var titleStyle = lipgloss.NewStyle().
-	Margin(0, 0, 0, 1).
-	Foreground(theme.Primary).
-	Bold(true)
 
 // FetchedMsg carries the result of an issues fetch.
 type FetchedMsg struct {
@@ -81,13 +74,15 @@ type Model struct {
 	SelectedBoard string
 	Loading       bool
 	SpinnerView   string
+	theme         style.Theme
 	width         int
 	height        int
 }
 
-func New() Model {
+func New(t style.Theme) Model {
 	return Model{
 		Table: table.New(table.WithFocused(true)),
+		theme: t,
 	}
 }
 
@@ -129,7 +124,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if h < 3 {
 			h = 3
 		}
-		s := table.ThemedStyles(theme)
+		s := table.ThemedStyles(m.theme)
 		m.Table = table.InitModel(table.InitModelParams{
 			Rows:   rows,
 			Colums: getTableCols(tableW),
@@ -176,11 +171,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m Model) View() tea.View {
 	header := fmt.Sprintf("%s - Issues", m.SelectedBoard)
-	return tea.NewView(table.RenderPanel(theme, &m.Table, m.Loading, m.SpinnerView, header))
+	return tea.NewView(table.RenderPanel(m.theme, &m.Table, m.Loading, m.SpinnerView, header))
 }
 
 func (m Model) tableWidth() int {
-	return m.width - table.DocStyle(theme).GetHorizontalFrameSize() - tableBorderX
+	return m.width - table.DocStyle(m.theme).GetHorizontalFrameSize() - tableBorderX
 }
 
 func issueToRow(i jira.Issue) table.Row {

--- a/internal/tui/issues/issues.go
+++ b/internal/tui/issues/issues.go
@@ -12,11 +12,10 @@ import (
 	"github.com/felipeospina21/jiraf/internal/tui"
 	"github.com/felipeospina21/jiraf/internal/tui/icon"
 	"github.com/felipeospina21/tuishell"
-	"github.com/felipeospina21/tuishell/style"
 	"github.com/felipeospina21/tuishell/table"
 )
 
-var theme = style.DefaultTheme()
+var theme = tui.DefaultTheme()
 
 const (
 	tableBorderX  = 2

--- a/internal/tui/presets.go
+++ b/internal/tui/presets.go
@@ -1,0 +1,43 @@
+package tui
+
+import (
+	"charm.land/lipgloss/v2"
+	"github.com/felipeospina21/tuishell/style"
+)
+
+var presets = map[string]style.Theme{
+	"catppuccin-mocha": {
+		Primary:       lipgloss.Color("#89b4fa"),  // Blue
+		PrimaryBright: lipgloss.Color("#b4befe"),  // Lavender
+		PrimaryFg:     lipgloss.Color("#cdd6f4"),  // Text
+		PrimaryDim:    lipgloss.Color("#45475a"),  // Surface1
+
+		Info:          lipgloss.Color("#74c7ec"),  // Sapphire
+		InfoBright:    lipgloss.Color("#89dceb"),  // Sky
+		Success:       lipgloss.Color("#a6e3a1"),  // Green
+		SuccessBright: lipgloss.Color("#94e2d5"),  // Teal
+		Danger:        lipgloss.Color("#f38ba8"),  // Red
+		DangerBright:  lipgloss.Color("#eba0ac"),  // Maroon
+		Warning:       lipgloss.Color("#f9e2af"),  // Yellow
+		WarningBright: lipgloss.Color("#fab387"),  // Peach
+		Caution:       lipgloss.Color("#fab387"),  // Peach
+
+		Text:            lipgloss.Color("#cdd6f4"),  // Text
+		TextInverse:     lipgloss.Color("#11111b"),  // Crust
+		TextDimmed:      lipgloss.Color("#a6adc8"),  // Subtext0
+		Muted:           lipgloss.Color("#9399b2"),  // Overlay2
+		Dim:             lipgloss.Color("#6c7086"),  // Overlay0
+		Border:          lipgloss.Color("#585b70"),  // Surface2
+		ModalBorder:     lipgloss.Color("#7f849c"),  // Overlay1
+		SurfaceDim:      lipgloss.Color("#1e1e2e"),  // Base
+		SelectionBorder: lipgloss.Color("#cba6f7"),  // Mauve
+
+		StatusText:    lipgloss.Color("#cdd6f4"),  // Text
+		StatusNormal:  lipgloss.Color("#45475a"),  // Surface1
+		StatusLoading: lipgloss.Color("#94e2d5"),  // Teal
+		StatusError:   lipgloss.Color("#f38ba8"),  // Red
+		StatusDev:     lipgloss.Color("#a6e3a1"),  // Green
+		StatusAccent1: lipgloss.Color("#cba6f7"),  // Mauve
+		StatusAccent2: lipgloss.Color("#b4befe"),  // Lavender
+	},
+}

--- a/internal/tui/presets.go
+++ b/internal/tui/presets.go
@@ -6,6 +6,7 @@ import (
 )
 
 var presets = map[string]style.Theme{
+	// ── Catppuccin Mocha (dark) ──
 	"catppuccin-mocha": {
 		Primary:       lipgloss.Color("#89b4fa"),  // Blue
 		PrimaryBright: lipgloss.Color("#b4befe"),  // Lavender
@@ -39,5 +40,221 @@ var presets = map[string]style.Theme{
 		StatusDev:     lipgloss.Color("#a6e3a1"),  // Green
 		StatusAccent1: lipgloss.Color("#cba6f7"),  // Mauve
 		StatusAccent2: lipgloss.Color("#b4befe"),  // Lavender
+	},
+
+	// ── Catppuccin Macchiato ──
+	"catppuccin-macchiato": {
+		Primary:       lipgloss.Color("#8aadf4"),  // Blue
+		PrimaryBright: lipgloss.Color("#b7bdf8"),  // Lavender
+		PrimaryFg:     lipgloss.Color("#cad3f5"),  // Text
+		PrimaryDim:    lipgloss.Color("#494d64"),  // Surface1
+
+		Info:          lipgloss.Color("#7dc4e4"),  // Sapphire
+		InfoBright:    lipgloss.Color("#91d7e3"),  // Sky
+		Success:       lipgloss.Color("#a6da95"),  // Green
+		SuccessBright: lipgloss.Color("#8bd5ca"),  // Teal
+		Danger:        lipgloss.Color("#ed8796"),  // Red
+		DangerBright:  lipgloss.Color("#ee99a0"),  // Maroon
+		Warning:       lipgloss.Color("#eed49f"),  // Yellow
+		WarningBright: lipgloss.Color("#f5a97f"),  // Peach
+		Caution:       lipgloss.Color("#f5a97f"),  // Peach
+
+		Text:            lipgloss.Color("#cad3f5"),  // Text
+		TextInverse:     lipgloss.Color("#181926"),  // Crust
+		TextDimmed:      lipgloss.Color("#a5adcb"),  // Subtext0
+		Muted:           lipgloss.Color("#939ab7"),  // Overlay2
+		Dim:             lipgloss.Color("#6e738d"),  // Overlay0
+		Border:          lipgloss.Color("#5b6078"),  // Surface2
+		ModalBorder:     lipgloss.Color("#8087a2"),  // Overlay1
+		SurfaceDim:      lipgloss.Color("#24273a"),  // Base
+		SelectionBorder: lipgloss.Color("#c6a0f6"),  // Mauve
+
+		StatusText:    lipgloss.Color("#cad3f5"),  // Text
+		StatusNormal:  lipgloss.Color("#494d64"),  // Surface1
+		StatusLoading: lipgloss.Color("#8bd5ca"),  // Teal
+		StatusError:   lipgloss.Color("#ed8796"),  // Red
+		StatusDev:     lipgloss.Color("#a6da95"),  // Green
+		StatusAccent1: lipgloss.Color("#c6a0f6"),  // Mauve
+		StatusAccent2: lipgloss.Color("#b7bdf8"),  // Lavender
+	},
+
+	// ── Catppuccin Frappé ──
+	"catppuccin-frappe": {
+		Primary:       lipgloss.Color("#8caaee"),  // Blue
+		PrimaryBright: lipgloss.Color("#babbf1"),  // Lavender
+		PrimaryFg:     lipgloss.Color("#c6d0f5"),  // Text
+		PrimaryDim:    lipgloss.Color("#51576d"),  // Surface1
+
+		Info:          lipgloss.Color("#85c1dc"),  // Sapphire
+		InfoBright:    lipgloss.Color("#99d1db"),  // Sky
+		Success:       lipgloss.Color("#a6d189"),  // Green
+		SuccessBright: lipgloss.Color("#81c8be"),  // Teal
+		Danger:        lipgloss.Color("#e78284"),  // Red
+		DangerBright:  lipgloss.Color("#ea999c"),  // Maroon
+		Warning:       lipgloss.Color("#e5c890"),  // Yellow
+		WarningBright: lipgloss.Color("#ef9f76"),  // Peach
+		Caution:       lipgloss.Color("#ef9f76"),  // Peach
+
+		Text:            lipgloss.Color("#c6d0f5"),  // Text
+		TextInverse:     lipgloss.Color("#232634"),  // Crust
+		TextDimmed:      lipgloss.Color("#a5adce"),  // Subtext0
+		Muted:           lipgloss.Color("#949cbb"),  // Overlay2
+		Dim:             lipgloss.Color("#737994"),  // Overlay0
+		Border:          lipgloss.Color("#626880"),  // Surface2
+		ModalBorder:     lipgloss.Color("#838ba7"),  // Overlay1
+		SurfaceDim:      lipgloss.Color("#303446"),  // Base
+		SelectionBorder: lipgloss.Color("#ca9ee6"),  // Mauve
+
+		StatusText:    lipgloss.Color("#c6d0f5"),  // Text
+		StatusNormal:  lipgloss.Color("#51576d"),  // Surface1
+		StatusLoading: lipgloss.Color("#81c8be"),  // Teal
+		StatusError:   lipgloss.Color("#e78284"),  // Red
+		StatusDev:     lipgloss.Color("#a6d189"),  // Green
+		StatusAccent1: lipgloss.Color("#ca9ee6"),  // Mauve
+		StatusAccent2: lipgloss.Color("#babbf1"),  // Lavender
+	},
+
+	// ── Catppuccin Latte (light) ──
+	"catppuccin-latte": {
+		Primary:       lipgloss.Color("#1e66f5"),  // Blue
+		PrimaryBright: lipgloss.Color("#7287fd"),  // Lavender
+		PrimaryFg:     lipgloss.Color("#4c4f69"),  // Text
+		PrimaryDim:    lipgloss.Color("#bcc0cc"),  // Surface1
+
+		Info:          lipgloss.Color("#209fb5"),  // Sapphire
+		InfoBright:    lipgloss.Color("#04a5e5"),  // Sky
+		Success:       lipgloss.Color("#40a02b"),  // Green
+		SuccessBright: lipgloss.Color("#179299"),  // Teal
+		Danger:        lipgloss.Color("#d20f39"),  // Red
+		DangerBright:  lipgloss.Color("#e64553"),  // Maroon
+		Warning:       lipgloss.Color("#df8e1d"),  // Yellow
+		WarningBright: lipgloss.Color("#fe640b"),  // Peach
+		Caution:       lipgloss.Color("#fe640b"),  // Peach
+
+		Text:            lipgloss.Color("#4c4f69"),  // Text
+		TextInverse:     lipgloss.Color("#eff1f5"),  // Base
+		TextDimmed:      lipgloss.Color("#6c6f85"),  // Subtext0
+		Muted:           lipgloss.Color("#7c7f93"),  // Overlay2
+		Dim:             lipgloss.Color("#9ca0b0"),  // Overlay0
+		Border:          lipgloss.Color("#acb0be"),  // Surface2
+		ModalBorder:     lipgloss.Color("#8c8fa1"),  // Overlay1
+		SurfaceDim:      lipgloss.Color("#eff1f5"),  // Base
+		SelectionBorder: lipgloss.Color("#8839ef"),  // Mauve
+
+		StatusText:    lipgloss.Color("#eff1f5"),  // Base
+		StatusNormal:  lipgloss.Color("#bcc0cc"),  // Surface1
+		StatusLoading: lipgloss.Color("#179299"),  // Teal
+		StatusError:   lipgloss.Color("#d20f39"),  // Red
+		StatusDev:     lipgloss.Color("#40a02b"),  // Green
+		StatusAccent1: lipgloss.Color("#8839ef"),  // Mauve
+		StatusAccent2: lipgloss.Color("#7287fd"),  // Lavender
+	},
+
+	// ── Rosé Pine ──
+	"rose-pine": {
+		Primary:       lipgloss.Color("#c4a7e7"),  // Iris
+		PrimaryBright: lipgloss.Color("#ebbcba"),  // Rose
+		PrimaryFg:     lipgloss.Color("#e0def4"),  // Text
+		PrimaryDim:    lipgloss.Color("#26233a"),  // Highlight Med
+
+		Info:          lipgloss.Color("#9ccfd8"),  // Foam
+		InfoBright:    lipgloss.Color("#c4a7e7"),  // Iris
+		Success:       lipgloss.Color("#9ccfd8"),  // Foam
+		SuccessBright: lipgloss.Color("#3e8fb0"),  // Pine
+		Danger:        lipgloss.Color("#eb6f92"),  // Love
+		DangerBright:  lipgloss.Color("#eb6f92"),  // Love
+		Warning:       lipgloss.Color("#f6c177"),  // Gold
+		WarningBright: lipgloss.Color("#f6c177"),  // Gold
+		Caution:       lipgloss.Color("#ebbcba"),  // Rose
+
+		Text:            lipgloss.Color("#e0def4"),  // Text
+		TextInverse:     lipgloss.Color("#191724"),  // Base
+		TextDimmed:      lipgloss.Color("#908caa"),  // Subtle
+		Muted:           lipgloss.Color("#6e6a86"),  // Muted
+		Dim:             lipgloss.Color("#524f67"),  // Highlight High
+		Border:          lipgloss.Color("#403d52"),  // Highlight Med
+		ModalBorder:     lipgloss.Color("#524f67"),  // Highlight High
+		SurfaceDim:      lipgloss.Color("#191724"),  // Base
+		SelectionBorder: lipgloss.Color("#c4a7e7"),  // Iris
+
+		StatusText:    lipgloss.Color("#e0def4"),  // Text
+		StatusNormal:  lipgloss.Color("#21202e"),  // Surface
+		StatusLoading: lipgloss.Color("#9ccfd8"),  // Foam
+		StatusError:   lipgloss.Color("#eb6f92"),  // Love
+		StatusDev:     lipgloss.Color("#3e8fb0"),  // Pine
+		StatusAccent1: lipgloss.Color("#c4a7e7"),  // Iris
+		StatusAccent2: lipgloss.Color("#ebbcba"),  // Rose
+	},
+
+	// ── Tokyo Night ──
+	"tokyo-night": {
+		Primary:       lipgloss.Color("#7aa2f7"),  // Blue
+		PrimaryBright: lipgloss.Color("#2ac3de"),  // Cyan
+		PrimaryFg:     lipgloss.Color("#c0caf5"),  // Foreground
+		PrimaryDim:    lipgloss.Color("#3b4261"),  // Comment
+
+		Info:          lipgloss.Color("#7dcfff"),  // Light Blue
+		InfoBright:    lipgloss.Color("#2ac3de"),  // Cyan
+		Success:       lipgloss.Color("#9ece6a"),  // Green
+		SuccessBright: lipgloss.Color("#73daca"),  // Teal
+		Danger:        lipgloss.Color("#f7768e"),  // Red
+		DangerBright:  lipgloss.Color("#ff9e64"),  // Orange
+		Warning:       lipgloss.Color("#e0af68"),  // Yellow
+		WarningBright: lipgloss.Color("#ff9e64"),  // Orange
+		Caution:       lipgloss.Color("#ff9e64"),  // Orange
+
+		Text:            lipgloss.Color("#c0caf5"),  // Foreground
+		TextInverse:     lipgloss.Color("#1a1b26"),  // Background
+		TextDimmed:      lipgloss.Color("#a9b1d6"),  // Fg Dark
+		Muted:           lipgloss.Color("#565f89"),  // Comment
+		Dim:             lipgloss.Color("#3b4261"),  // Line
+		Border:          lipgloss.Color("#292e42"),  // Bg Highlight
+		ModalBorder:     lipgloss.Color("#565f89"),  // Comment
+		SurfaceDim:      lipgloss.Color("#1a1b26"),  // Background
+		SelectionBorder: lipgloss.Color("#bb9af7"),  // Purple
+
+		StatusText:    lipgloss.Color("#c0caf5"),  // Foreground
+		StatusNormal:  lipgloss.Color("#292e42"),  // Bg Highlight
+		StatusLoading: lipgloss.Color("#73daca"),  // Teal
+		StatusError:   lipgloss.Color("#f7768e"),  // Red
+		StatusDev:     lipgloss.Color("#9ece6a"),  // Green
+		StatusAccent1: lipgloss.Color("#bb9af7"),  // Purple
+		StatusAccent2: lipgloss.Color("#7aa2f7"),  // Blue
+	},
+
+	// ── Dracula ──
+	"dracula": {
+		Primary:       lipgloss.Color("#bd93f9"),  // Purple
+		PrimaryBright: lipgloss.Color("#ff79c6"),  // Pink
+		PrimaryFg:     lipgloss.Color("#f8f8f2"),  // Foreground
+		PrimaryDim:    lipgloss.Color("#44475a"),  // Current Line
+
+		Info:          lipgloss.Color("#8be9fd"),  // Cyan
+		InfoBright:    lipgloss.Color("#bd93f9"),  // Purple
+		Success:       lipgloss.Color("#50fa7b"),  // Green
+		SuccessBright: lipgloss.Color("#50fa7b"),  // Green
+		Danger:        lipgloss.Color("#ff5555"),  // Red
+		DangerBright:  lipgloss.Color("#ff6e6e"),  // Red bright
+		Warning:       lipgloss.Color("#f1fa8c"),  // Yellow
+		WarningBright: lipgloss.Color("#ffb86c"),  // Orange
+		Caution:       lipgloss.Color("#ffb86c"),  // Orange
+
+		Text:            lipgloss.Color("#f8f8f2"),  // Foreground
+		TextInverse:     lipgloss.Color("#282a36"),  // Background
+		TextDimmed:      lipgloss.Color("#bfbfbf"),  // Fg dimmed
+		Muted:           lipgloss.Color("#6272a4"),  // Comment
+		Dim:             lipgloss.Color("#44475a"),  // Current Line
+		Border:          lipgloss.Color("#44475a"),  // Current Line
+		ModalBorder:     lipgloss.Color("#6272a4"),  // Comment
+		SurfaceDim:      lipgloss.Color("#282a36"),  // Background
+		SelectionBorder: lipgloss.Color("#ff79c6"),  // Pink
+
+		StatusText:    lipgloss.Color("#f8f8f2"),  // Foreground
+		StatusNormal:  lipgloss.Color("#44475a"),  // Current Line
+		StatusLoading: lipgloss.Color("#8be9fd"),  // Cyan
+		StatusError:   lipgloss.Color("#ff5555"),  // Red
+		StatusDev:     lipgloss.Color("#50fa7b"),  // Green
+		StatusAccent1: lipgloss.Color("#bd93f9"),  // Purple
+		StatusAccent2: lipgloss.Color("#ff79c6"),  // Pink
 	},
 }

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,9 +1,53 @@
 package tui
 
 import (
+	"image/color"
+
 	"charm.land/lipgloss/v2"
+	"github.com/felipeospina21/jiraf/internal/config"
 	"github.com/felipeospina21/tuishell/style"
 )
+
+func applyOverride(target *color.Color, val *string) {
+	if val != nil {
+		*target = lipgloss.Color(*val)
+	}
+}
+
+// BuildTheme returns DefaultTheme with any non-nil overrides applied.
+func BuildTheme(overrides config.ThemeOverrides) style.Theme {
+	t := DefaultTheme()
+	applyOverride(&t.Primary, overrides.Primary)
+	applyOverride(&t.PrimaryBright, overrides.PrimaryBright)
+	applyOverride(&t.PrimaryFg, overrides.PrimaryFg)
+	applyOverride(&t.PrimaryDim, overrides.PrimaryDim)
+	applyOverride(&t.Info, overrides.Info)
+	applyOverride(&t.InfoBright, overrides.InfoBright)
+	applyOverride(&t.Success, overrides.Success)
+	applyOverride(&t.SuccessBright, overrides.SuccessBright)
+	applyOverride(&t.Danger, overrides.Danger)
+	applyOverride(&t.DangerBright, overrides.DangerBright)
+	applyOverride(&t.Warning, overrides.Warning)
+	applyOverride(&t.WarningBright, overrides.WarningBright)
+	applyOverride(&t.Caution, overrides.Caution)
+	applyOverride(&t.Text, overrides.Text)
+	applyOverride(&t.TextInverse, overrides.TextInverse)
+	applyOverride(&t.TextDimmed, overrides.TextDimmed)
+	applyOverride(&t.Muted, overrides.Muted)
+	applyOverride(&t.Dim, overrides.Dim)
+	applyOverride(&t.Border, overrides.Border)
+	applyOverride(&t.ModalBorder, overrides.ModalBorder)
+	applyOverride(&t.SurfaceDim, overrides.SurfaceDim)
+	applyOverride(&t.SelectionBorder, overrides.SelectionBorder)
+	applyOverride(&t.StatusText, overrides.StatusText)
+	applyOverride(&t.StatusNormal, overrides.StatusNormal)
+	applyOverride(&t.StatusLoading, overrides.StatusLoading)
+	applyOverride(&t.StatusError, overrides.StatusError)
+	applyOverride(&t.StatusDev, overrides.StatusDev)
+	applyOverride(&t.StatusAccent1, overrides.StatusAccent1)
+	applyOverride(&t.StatusAccent2, overrides.StatusAccent2)
+	return t
+}
 
 // DefaultTheme returns a Jira/Atlassian blue theme.
 func DefaultTheme() style.Theme {

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,0 +1,44 @@
+package tui
+
+import (
+	"charm.land/lipgloss/v2"
+	"github.com/felipeospina21/tuishell/style"
+)
+
+// DefaultTheme returns a Jira/Atlassian blue theme.
+func DefaultTheme() style.Theme {
+	return style.Theme{
+		Primary:       lipgloss.Color("#2684FF"),
+		PrimaryBright: lipgloss.Color("#0065FF"),
+		PrimaryFg:     lipgloss.Color("#DEEBFF"),
+		PrimaryDim:    lipgloss.Color("#002B6B"),
+
+		Info:          lipgloss.Color("#4C9AFF"),
+		InfoBright:    lipgloss.Color("#2684FF"),
+		Success:       lipgloss.Color("#6beaaf"),
+		SuccessBright: lipgloss.Color("#3ad994"),
+		Danger:        lipgloss.Color("#f9a8a8"),
+		DangerBright:  lipgloss.Color("#f47575"),
+		Warning:       lipgloss.Color("#ffe043"),
+		WarningBright: lipgloss.Color("#ffcc14"),
+		Caution:       lipgloss.Color("#ff8237"),
+
+		Text:            lipgloss.Color("#C4C4C4"),
+		TextInverse:     lipgloss.Color("#111"),
+		TextDimmed:      lipgloss.Color("#777777"),
+		Muted:           lipgloss.Color("#999999"),
+		Dim:             lipgloss.Color("#444444"),
+		Border:          lipgloss.Color("#3f4145"),
+		ModalBorder:     lipgloss.Color("#666666"),
+		SurfaceDim:      lipgloss.Color("#091E42"),
+		SelectionBorder: lipgloss.Color("#0052CC"),
+
+		StatusText:    lipgloss.Color("#FFFDF5"),
+		StatusNormal:  lipgloss.Color("#0747A6"),
+		StatusLoading: lipgloss.Color("#1A7A94"),
+		StatusError:   lipgloss.Color("#CE3060"),
+		StatusDev:     lipgloss.Color("#4E8212"),
+		StatusAccent1: lipgloss.Color("#0065FF"),
+		StatusAccent2: lipgloss.Color("#003884"),
+	}
+}

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -17,6 +17,11 @@ func applyOverride(target *color.Color, val *string) {
 // BuildTheme returns DefaultTheme with any non-nil overrides applied.
 func BuildTheme(overrides config.ThemeOverrides) style.Theme {
 	t := DefaultTheme()
+	if overrides.Preset != nil {
+		if preset, ok := presets[*overrides.Preset]; ok {
+			t = preset
+		}
+	}
 	applyOverride(&t.Primary, overrides.Primary)
 	applyOverride(&t.PrimaryBright, overrides.PrimaryBright)
 	applyOverride(&t.PrimaryFg, overrides.PrimaryFg)


### PR DESCRIPTION
## Summary

Implements #24 — custom theme colors via config.

### Changes

- **Jiraf-specific default theme**: Jira/Atlassian blue palette defined in `internal/tui/theme.go`, replacing `style.DefaultTheme()` from tuishell
- **Theme overrides via config**: `[theme]` section in TOML config with 30 optional color tokens. Unspecified tokens fall back to the default or preset palette
- **Preset themes**: 7 preconfigured palettes — catppuccin-mocha, catppuccin-macchiato, catppuccin-frappe, catppuccin-latte, rose-pine, tokyo-night, dracula
- **Theme threading**: Theme is built once in `NewApp()` and passed to all components instead of hardcoded package-level vars
- **Styled boards panel**: Left panel uses custom delegate with theme colors instead of bubbles defaults
- **Docs**: README updated with theme configuration guide, token reference table, and preset list

### Config example

```toml
[theme]
preset = "catppuccin-mocha"
# optional individual overrides on top
# primary = "#FF0000"
```

Closes #24