### PR TITLE
feat: server-side issue filtering via JQL (#10)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	charm.land/glamour/v2 v2.0.0
 	charm.land/lipgloss/v2 v2.0.2
 	github.com/charmbracelet/x/ansi v0.11.6
-	github.com/felipeospina21/tuishell v0.9.0
+	github.com/felipeospina21/tuishell v0.10.0
 	github.com/spf13/viper v1.21.0
 	golang.org/x/net v0.52.0
 )

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/felipeospina21/tuishell v0.9.0 h1:ahphIKbowXXX98LkuPrdybaSVRg33vXbeUpTGkoLrt8=
-github.com/felipeospina21/tuishell v0.9.0/go.mod h1:PdkAVJRM2ug1qKEuW+myzWJy0Q5sILUlU+gMN6sU/h0=
+github.com/felipeospina21/tuishell v0.10.0 h1:2Bd7WceYfLONUOOiQ0DFxx87xHMILO/2HhMKsgReeSM=
+github.com/felipeospina21/tuishell v0.10.0/go.mod h1:PdkAVJRM2ug1qKEuW+myzWJy0Q5sILUlU+gMN6sU/h0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=

--- a/internal/jira/issues.go
+++ b/internal/jira/issues.go
@@ -32,6 +32,8 @@ func (c *Client) GetMyIssues(projectKey string, filters IssueFilters) ([]Issue, 
 	jql := fmt.Sprintf("assignee=currentUser() AND project=%s", projectKey)
 	if len(filters.Statuses) > 0 {
 		jql += fmt.Sprintf(` AND status IN ("%s")`, strings.Join(filters.Statuses, `", "`))
+	} else {
+		jql += ` AND status NOT IN (Done, Withdrawn)`
 	}
 	if len(filters.Priorities) > 0 {
 		jql += fmt.Sprintf(` AND priority IN ("%s")`, strings.Join(filters.Priorities, `", "`))

--- a/internal/jira/issues.go
+++ b/internal/jira/issues.go
@@ -3,19 +3,44 @@ package jira
 import (
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 )
 
 const issueFields = "summary,description,status,priority,issuetype,assignee,reporter,created,updated,labels,components,fixVersions,subtasks,comment,customfield_10106,customfield_10105"
 
+// IssueFilters holds optional JQL filter criteria.
+type IssueFilters struct {
+	Statuses   []string
+	Priorities []string
+	Types      []string
+}
+
+// HasActive reports whether any filter is set.
+func (f IssueFilters) HasActive() bool {
+	return len(f.Statuses) > 0 || len(f.Priorities) > 0 || len(f.Types) > 0
+}
+
 // GetMyIssues fetches issues assigned to the current user for a given project key.
-func (c *Client) GetMyIssues(projectKey string) ([]Issue, error) {
+func (c *Client) GetMyIssues(projectKey string, filters IssueFilters) ([]Issue, error) {
 	if c.demoMode {
 		time.Sleep(1 * time.Second)
 		return MockIssues, nil
 	}
 
-	jql := fmt.Sprintf("assignee=currentUser() AND project=%s AND status NOT IN (Done, Withdrawn) ORDER BY priority DESC, updated DESC", projectKey)
+	jql := fmt.Sprintf("assignee=currentUser() AND project=%s", projectKey)
+	if len(filters.Statuses) > 0 {
+		jql += fmt.Sprintf(` AND status IN ("%s")`, strings.Join(filters.Statuses, `", "`))
+	}
+	if len(filters.Priorities) > 0 {
+		jql += fmt.Sprintf(` AND priority IN ("%s")`, strings.Join(filters.Priorities, `", "`))
+	}
+	if len(filters.Types) > 0 {
+		jql += fmt.Sprintf(` AND issuetype IN ("%s")`, strings.Join(filters.Types, `", "`))
+	}
+
+	jql += " ORDER BY priority DESC, updated DESC"
+
 	path := fmt.Sprintf("/rest/api/2/search?jql=%s&fields=%s&expand=renderedFields&maxResults=50", url.QueryEscape(jql), issueFields)
 
 	var resp SearchResponse

--- a/internal/jira/issues.go
+++ b/internal/jira/issues.go
@@ -14,11 +14,12 @@ type IssueFilters struct {
 	Statuses   []string
 	Priorities []string
 	Types      []string
+	Sprint     string
 }
 
 // HasActive reports whether any filter is set.
 func (f IssueFilters) HasActive() bool {
-	return len(f.Statuses) > 0 || len(f.Priorities) > 0 || len(f.Types) > 0
+	return len(f.Statuses) > 0 || len(f.Priorities) > 0 || len(f.Types) > 0 || f.Sprint != ""
 }
 
 // GetMyIssues fetches issues assigned to the current user for a given project key.
@@ -37,6 +38,9 @@ func (c *Client) GetMyIssues(projectKey string, filters IssueFilters) ([]Issue, 
 	}
 	if len(filters.Types) > 0 {
 		jql += fmt.Sprintf(` AND issuetype IN ("%s")`, strings.Join(filters.Types, `", "`))
+	}
+	if filters.Sprint != "" {
+		jql += fmt.Sprintf(` AND sprint = "Sprint %s"`, filters.Sprint)
 	}
 
 	jql += " ORDER BY priority DESC, updated DESC"

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -62,6 +62,7 @@ func NewApp() tea.Model {
 		Shell:            s,
 		Details:          &det,
 		client:           client,
+		filterPopover:    popover.NewFilter(theme),
 		confirmPopover:   popover.NewConfirm(theme),
 		transitionPicker: popover.NewList(theme),
 	}

--- a/internal/tui/app/commands.go
+++ b/internal/tui/app/commands.go
@@ -6,8 +6,9 @@ import (
 )
 
 func (m Model) fetchIssues(projectKey string) tea.Cmd {
+	filters := m.activeFilters
 	return func() tea.Msg {
-		iss, err := m.client.GetMyIssues(projectKey)
+		iss, err := m.client.GetMyIssues(projectKey, filters)
 		return issues.FetchedMsg{Issues: iss, Err: err}
 	}
 }

--- a/internal/tui/app/model.go
+++ b/internal/tui/app/model.go
@@ -17,6 +17,13 @@ type Model struct {
 	Details *details.Model
 	client  *jira.Client
 
+	// Filter state
+	filterPopover    popover.FilterModel
+	activeFilters    jira.IssueFilters
+	knownStatuses    map[string]bool
+	knownPriorities  map[string]bool
+	knownTypes       map[string]bool
+
 	// Transition state
 	pendingTransition     string // issue key awaiting transition
 	pendingTransitionName string // selected transition name awaiting confirmation

--- a/internal/tui/app/update.go
+++ b/internal/tui/app/update.go
@@ -163,7 +163,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.knownTypes[v] = true
 		}
 		sections := buildFilterSections(m.knownStatuses, m.knownPriorities, m.knownTypes, m.activeFilters)
-		m.filterPopover.Open(sections)
+		inputs := []tuishell.FilterInput{
+			{Title: "Sprint", Placeholder: "e.g. 42", Value: m.activeFilters.Sprint},
+		}
+		m.filterPopover.Open(sections, inputs)
 		return m, nil
 
 	case tuishell.ApplyFilterPopoverMsg:
@@ -172,6 +175,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			Statuses:   msg.Selections["Status"],
 			Priorities: msg.Selections["Priority"],
 			Types:      msg.Selections["Type"],
+			Sprint:     strings.TrimSpace(msg.Inputs["Sprint"]),
 		}
 		if main, ok := m.Shell.Main.(issues.Model); ok && main.SelectedBoard != "" {
 			main.Loading = true
@@ -318,6 +322,9 @@ func filterStatusText(f jira.IssueFilters) string {
 	}
 	if len(f.Types) > 0 {
 		parts = append(parts, fmt.Sprintf("Type(%d)", len(f.Types)))
+	}
+	if f.Sprint != "" {
+		parts = append(parts, fmt.Sprintf("Sprint %s", f.Sprint))
 	}
 	return "Filtered: " + strings.Join(parts, ", ")
 }

--- a/internal/tui/app/update.go
+++ b/internal/tui/app/update.go
@@ -144,10 +144,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case issues.OpenFilterMsg:
 		// Include active filter values in known sets so they always appear
+		if m.knownStatuses == nil {
+			m.knownStatuses = map[string]bool{}
+		}
+		// Always include excluded-by-default statuses so they're visible
+		m.knownStatuses["Done"] = true
+		m.knownStatuses["Withdrawn"] = true
 		for _, v := range m.activeFilters.Statuses {
-			if m.knownStatuses == nil {
-				m.knownStatuses = map[string]bool{}
-			}
 			m.knownStatuses[v] = true
 		}
 		for _, v := range m.activeFilters.Priorities {
@@ -305,8 +308,16 @@ func buildFilterSections(statuses, priorities, types map[string]bool, active jir
 		return tuishell.FilterSection{Title: title, Options: opts}
 	}
 
+	statusSection := makeSection("Status", statuses, active.Statuses)
+	// Default: select all statuses except Done and Withdrawn when no filter is active
+	if len(active.Statuses) == 0 {
+		for i, opt := range statusSection.Options {
+			statusSection.Options[i].Selected = opt.Value != "Done" && opt.Value != "Withdrawn"
+		}
+	}
+
 	return []tuishell.FilterSection{
-		makeSection("Status", statuses, active.Statuses),
+		statusSection,
 		makeSection("Priority", priorities, active.Priorities),
 		makeSection("Type", types, active.Types),
 	}

--- a/internal/tui/app/update.go
+++ b/internal/tui/app/update.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/felipeospina21/jiraf/internal/config"
@@ -26,7 +28,11 @@ type TransitionDoneMsg struct {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case boards.SelectBoardMsg:
-		// Update the board name and set loading state on the issues panel
+		// Reset filters and known values when switching boards
+		m.activeFilters = jira.IssueFilters{}
+		m.knownStatuses = nil
+		m.knownPriorities = nil
+		m.knownTypes = nil
 		if main, ok := m.Shell.Main.(issues.Model); ok {
 			main.SelectedBoard = msg.Key
 			main.Loading = true
@@ -37,6 +43,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			func() tea.Msg { return tuishell.CloseLeftPanelMsg{} },
 			func() tea.Msg { return tuishell.StartTaskMsg{Cmd: m.fetchIssues(msg.Key)} },
 		)
+
+	case issues.FetchedMsg:
+		// Collect known filter values from fetched issues
+		if msg.Err == nil {
+			if m.knownStatuses == nil {
+				m.knownStatuses = map[string]bool{}
+			}
+			if m.knownPriorities == nil {
+				m.knownPriorities = map[string]bool{}
+			}
+			if m.knownTypes == nil {
+				m.knownTypes = map[string]bool{}
+			}
+			for _, i := range msg.Issues {
+				m.knownStatuses[i.Fields.Status.Name] = true
+				m.knownPriorities[i.Fields.Priority.Name] = true
+				m.knownTypes[i.Fields.IssueType.Name] = true
+			}
+		}
 
 	case issues.ViewDetailsMsg:
 		m.Details.SetContent(msg.Issue)
@@ -117,6 +142,72 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.transitionIDByName = nil
 		m.transitionPicker.Close()
 
+	case issues.OpenFilterMsg:
+		// Include active filter values in known sets so they always appear
+		for _, v := range m.activeFilters.Statuses {
+			if m.knownStatuses == nil {
+				m.knownStatuses = map[string]bool{}
+			}
+			m.knownStatuses[v] = true
+		}
+		for _, v := range m.activeFilters.Priorities {
+			if m.knownPriorities == nil {
+				m.knownPriorities = map[string]bool{}
+			}
+			m.knownPriorities[v] = true
+		}
+		for _, v := range m.activeFilters.Types {
+			if m.knownTypes == nil {
+				m.knownTypes = map[string]bool{}
+			}
+			m.knownTypes[v] = true
+		}
+		sections := buildFilterSections(m.knownStatuses, m.knownPriorities, m.knownTypes, m.activeFilters)
+		m.filterPopover.Open(sections)
+		return m, nil
+
+	case tuishell.ApplyFilterPopoverMsg:
+		m.filterPopover.Close()
+		m.activeFilters = jira.IssueFilters{
+			Statuses:   msg.Selections["Status"],
+			Priorities: msg.Selections["Priority"],
+			Types:      msg.Selections["Type"],
+		}
+		if main, ok := m.Shell.Main.(issues.Model); ok && main.SelectedBoard != "" {
+			main.Loading = true
+			main.SpinnerView = m.Shell.Spinner.View()
+			m.Shell.Main = main
+			var cmds []tea.Cmd
+			cmds = append(cmds, func() tea.Msg {
+				return tuishell.StartTaskMsg{Cmd: m.fetchIssues(main.SelectedBoard)}
+			})
+			if m.activeFilters.HasActive() {
+				cmds = append(cmds, func() tea.Msg {
+					return tuishell.SetStatusMsg{Content: filterStatusText(m.activeFilters)}
+				})
+			} else {
+				cmds = append(cmds, func() tea.Msg {
+					return tuishell.SetStatusMsg{Content: ""}
+				})
+			}
+			return m, tea.Batch(cmds...)
+		}
+
+	case tuishell.CloseFilterPopoverMsg:
+		m.filterPopover.Close()
+
+	case issues.ClearFilterMsg:
+		m.activeFilters = jira.IssueFilters{}
+		if main, ok := m.Shell.Main.(issues.Model); ok && main.SelectedBoard != "" {
+			main.Loading = true
+			main.SpinnerView = m.Shell.Spinner.View()
+			m.Shell.Main = main
+			return m, tea.Batch(
+				func() tea.Msg { return tuishell.SetStatusMsg{Content: ""} },
+				func() tea.Msg { return tuishell.StartTaskMsg{Cmd: m.fetchIssues(main.SelectedBoard)} },
+			)
+		}
+
 	case TransitionDoneMsg:
 		if msg.Err != nil {
 			return m, func() tea.Msg {
@@ -165,6 +256,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// Route keys to filter popover when open
+	if m.filterPopover.IsOpen() {
+		if _, ok := msg.(tea.KeyPressMsg); ok {
+			var cmd tea.Cmd
+			m.filterPopover, cmd = m.filterPopover.Update(msg)
+			return m, cmd
+		}
+	}
+
 	var cmd tea.Cmd
 	m.Shell, cmd = m.Shell.Update(msg)
 	m.syncKeybinds()
@@ -181,4 +281,43 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, cmd
+}
+
+func buildFilterSections(statuses, priorities, types map[string]bool, active jira.IssueFilters) []tuishell.FilterSection {
+	makeSection := func(title string, vals map[string]bool, selected []string) tuishell.FilterSection {
+		sel := map[string]bool{}
+		for _, v := range selected {
+			sel[v] = true
+		}
+		keys := make([]string, 0, len(vals))
+		for k := range vals {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		opts := make([]tuishell.FilterOption, len(keys))
+		for i, k := range keys {
+			opts[i] = tuishell.FilterOption{Label: k, Value: k, Selected: sel[k]}
+		}
+		return tuishell.FilterSection{Title: title, Options: opts}
+	}
+
+	return []tuishell.FilterSection{
+		makeSection("Status", statuses, active.Statuses),
+		makeSection("Priority", priorities, active.Priorities),
+		makeSection("Type", types, active.Types),
+	}
+}
+
+func filterStatusText(f jira.IssueFilters) string {
+	var parts []string
+	if len(f.Statuses) > 0 {
+		parts = append(parts, fmt.Sprintf("Status(%d)", len(f.Statuses)))
+	}
+	if len(f.Priorities) > 0 {
+		parts = append(parts, fmt.Sprintf("Priority(%d)", len(f.Priorities)))
+	}
+	if len(f.Types) > 0 {
+		parts = append(parts, fmt.Sprintf("Type(%d)", len(f.Types)))
+	}
+	return "Filtered: " + strings.Join(parts, ", ")
 }

--- a/internal/tui/app/view.go
+++ b/internal/tui/app/view.go
@@ -14,5 +14,9 @@ func (m Model) View() tea.View {
 		screen := m.transitionPicker.View(v.Content, w, h)
 		return tea.View{Content: screen, AltScreen: v.AltScreen}
 	}
+	if m.filterPopover.IsOpen() {
+		screen := m.filterPopover.View(v.Content, w, h)
+		return tea.View{Content: screen, AltScreen: v.AltScreen}
+	}
 	return v
 }

--- a/internal/tui/issues/issues.go
+++ b/internal/tui/issues/issues.go
@@ -168,9 +168,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case match(Keybinds.Refetch):
 			return m, func() tea.Msg { return RefetchMsg{} }
 		case match(Keybinds.Filter):
-			return m, func() tea.Msg { return OpenFilterMsg{} }
+			if len(m.Issues) > 0 {
+				return m, func() tea.Msg { return OpenFilterMsg{} }
+			}
 		case match(Keybinds.ClearFilter):
-			return m, func() tea.Msg { return ClearFilterMsg{} }
+			if len(m.Issues) > 0 {
+				return m, func() tea.Msg { return ClearFilterMsg{} }
+			}
 		}
 		var cmd tea.Cmd
 		m.Table, cmd = m.Table.Update(msg)

--- a/internal/tui/issues/issues.go
+++ b/internal/tui/issues/issues.go
@@ -46,6 +46,12 @@ type OpenInBrowserMsg struct {
 // RefetchMsg is sent when the user wants to refetch the issues list.
 type RefetchMsg struct{}
 
+// OpenFilterMsg is sent when the user wants to open the filter popover.
+type OpenFilterMsg struct{}
+
+// ClearFilterMsg is sent when the user wants to clear all active filters.
+type ClearFilterMsg struct{}
+
 var cols = []table.Column{
 	{Name: "created", Title: icon.Clock, Width: 3},
 	{Name: "priority", Title: "Priority", Width: 4, Centered: true},
@@ -161,6 +167,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case match(Keybinds.Refetch):
 			return m, func() tea.Msg { return RefetchMsg{} }
+		case match(Keybinds.Filter):
+			return m, func() tea.Msg { return OpenFilterMsg{} }
+		case match(Keybinds.ClearFilter):
+			return m, func() tea.Msg { return ClearFilterMsg{} }
 		}
 		var cmd tea.Cmd
 		m.Table, cmd = m.Table.Update(msg)

--- a/internal/tui/issues/keys.go
+++ b/internal/tui/issues/keys.go
@@ -12,12 +12,14 @@ type IssuesKeyMap struct {
 	OpenInBrowser key.Binding
 	Transition    key.Binding
 	Refetch       key.Binding
+	Filter        key.Binding
+	ClearFilter   key.Binding
 	tui.GlobalKeyMap
 }
 
 func (k IssuesKeyMap) ShortHelp() []key.Binding {
 	return slices.Concat(
-		[]key.Binding{k.Details, k.OpenInBrowser, k.Transition, k.Refetch},
+		[]key.Binding{k.Details, k.OpenInBrowser, k.Transition, k.Refetch, k.Filter, k.ClearFilter},
 		tui.CommonKeys,
 	)
 }
@@ -25,7 +27,7 @@ func (k IssuesKeyMap) ShortHelp() []key.Binding {
 func (k IssuesKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		tui.CommonKeys,
-		{k.Details, k.OpenInBrowser, k.Transition, k.Refetch},
+		{k.Details, k.OpenInBrowser, k.Transition, k.Refetch, k.Filter, k.ClearFilter},
 	}
 }
 
@@ -45,6 +47,14 @@ var Keybinds = IssuesKeyMap{
 	Refetch: key.NewBinding(
 		key.WithKeys("r"),
 		key.WithHelp("r", "refetch"),
+	),
+	Filter: key.NewBinding(
+		key.WithKeys("/"),
+		key.WithHelp("/", "filter"),
+	),
+	ClearFilter: key.NewBinding(
+		key.WithKeys("F"),
+		key.WithHelp("F", "clear filters"),
 	),
 	GlobalKeyMap: tui.GlobalKeys(false),
 }

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -58,7 +58,7 @@ func BuildTheme(overrides config.ThemeOverrides) style.Theme {
 func DefaultTheme() style.Theme {
 	return style.Theme{
 		Primary:       lipgloss.Color("#2684FF"),
-		PrimaryBright: lipgloss.Color("#0065FF"),
+		PrimaryBright: lipgloss.Color("#8AC4FF"),
 		PrimaryFg:     lipgloss.Color("#DEEBFF"),
 		PrimaryDim:    lipgloss.Color("#002B6B"),
 


### PR DESCRIPTION
## Summary

Add server-side JQL filtering for issues. Closes #10.

Depends on: felipeospina21/tuishell#25

## Changes

- `internal/jira/issues.go` — `IssueFilters` struct with Statuses, Priorities, Types, Sprint. Dynamic JQL builder with `IN` clauses. Default `status NOT IN (Done, Withdrawn)` when no status filter active.
- `internal/tui/issues/keys.go` — `/` to open filter, `F` to clear filters
- `internal/tui/issues/issues.go` — `OpenFilterMsg`, `ClearFilterMsg` types, guarded behind loaded issues check
- `internal/tui/app/` — Filter popover integration with known-values accumulation across fetches, sprint as text input, active filter indicator in statusline
- `internal/tui/theme.go` — Fixed `PrimaryBright` to `#8AC4FF` (genuinely brighter)

## Filter UX

- `/` opens filter popover with Status, Priority, Type (multi-select) and Sprint (text input)
- Tab/shift+tab navigates between fields, j/k within sections, space toggles
- Enter applies filters and re-fetches via JQL
- `F` clears all filters and re-fetches with defaults
- Statusline shows active filter summary
- Done/Withdrawn always visible in status section (unchecked by default)
- Known values accumulate across fetches so options persist after filtering

## Testing

- `make build` and `make test` pass
- Manual testing with demo mode