### PR TITLE
feat: add comment to issue from details panel

### DIFF
--- a/internal/jira/client.go
+++ b/internal/jira/client.go
@@ -56,6 +56,15 @@ func (c *Client) post(path string, body any) error {
 	return nil
 }
 
+// AddComment posts a comment on an issue.
+func (c *Client) AddComment(issueKey, body string) error {
+	if c.demoMode {
+		time.Sleep(500 * time.Millisecond)
+		return nil
+	}
+	return c.post(fmt.Sprintf("/rest/api/2/issue/%s/comment", issueKey), map[string]string{"body": body})
+}
+
 func (c *Client) get(path string, out any) error {
 	req, err := http.NewRequest("GET", c.baseURL+path, nil)
 	if err != nil {

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/felipeospina21/jiraf/internal/config"
@@ -58,9 +59,14 @@ func NewApp() tea.Model {
 		RightPanelStyle: rightPanelStyle,
 	})
 
+	ti := textarea.New()
+	ti.Placeholder = "Write your comment..."
+	ti.CharLimit = 0
+
 	return Model{
 		Shell:            s,
 		Details:          &det,
+		Input:            ti,
 		client:           client,
 		filterPopover:    popover.NewFilter(theme),
 		confirmPopover:   popover.NewConfirm(theme),

--- a/internal/tui/app/commands.go
+++ b/internal/tui/app/commands.go
@@ -26,3 +26,10 @@ func (m Model) doTransition(issueKey, transitionID string) tea.Cmd {
 		return TransitionDoneMsg{Err: err}
 	}
 }
+
+func (m Model) addComment(issueKey, body string) tea.Cmd {
+	return func() tea.Msg {
+		err := m.client.AddComment(issueKey, body)
+		return CommentAddedMsg{Err: err}
+	}
+}

--- a/internal/tui/app/model.go
+++ b/internal/tui/app/model.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"github.com/felipeospina21/jiraf/internal/jira"
 	"github.com/felipeospina21/jiraf/internal/tui/boards"
@@ -15,6 +16,7 @@ import (
 type Model struct {
 	Shell   shell.Model
 	Details *details.Model
+	Input   textarea.Model
 	client  *jira.Client
 
 	// Filter state
@@ -30,6 +32,9 @@ type Model struct {
 	confirmPopover        popover.ConfirmModel
 	transitionPicker      popover.ListModel
 	transitionIDByName    map[string]string
+
+	// Comment state
+	pendingComment string // issue key awaiting comment submission
 }
 
 func (m Model) Init() tea.Cmd {

--- a/internal/tui/app/update.go
+++ b/internal/tui/app/update.go
@@ -10,6 +10,7 @@ import (
 	jirafExec "github.com/felipeospina21/jiraf/internal/exec"
 	"github.com/felipeospina21/jiraf/internal/jira"
 	"github.com/felipeospina21/jiraf/internal/tui/boards"
+	"github.com/felipeospina21/jiraf/internal/tui/details"
 	"github.com/felipeospina21/jiraf/internal/tui/issues"
 	"github.com/felipeospina21/tuishell"
 )
@@ -22,6 +23,11 @@ type TransitionsFetchedMsg struct {
 
 // TransitionDoneMsg carries the result of executing a transition.
 type TransitionDoneMsg struct {
+	Err error
+}
+
+// CommentAddedMsg carries the result of adding a comment.
+type CommentAddedMsg struct {
 	Err error
 }
 
@@ -86,6 +92,54 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+	case details.CommentMsg:
+		m.pendingComment = msg.IssueKey
+		return m, tea.Batch(
+			func() tea.Msg {
+				return tuishell.OpenModalMsg{
+					Header:  fmt.Sprintf("Comment on %s", msg.IssueKey),
+					Content: m.Input.View(),
+				}
+			},
+			m.Input.Focus(),
+		)
+
+	case tuishell.ShellSubmitMsg:
+		if m.pendingComment != "" {
+			body := m.Input.Value()
+			if body == "" {
+				return m, nil
+			}
+			m.Input.Blur()
+			m.confirmPopover.Open(
+				"Add Comment",
+				fmt.Sprintf("Post comment on %s?", m.pendingComment),
+				"Submit",
+				"Cancel",
+			)
+			return m, nil
+		}
+
+	case tuishell.CloseModalMsg:
+		m.Input.Blur()
+		m.Input.Reset()
+		m.pendingComment = ""
+
+	case CommentAddedMsg:
+		if msg.Err != nil {
+			return m, func() tea.Msg {
+				return tuishell.FinishTaskMsg{Err: msg.Err}
+			}
+		}
+		return m, tea.Batch(
+			func() tea.Msg {
+				return tuishell.FinishTaskMsg{Err: nil, Keybinds: details.Keybinds}
+			},
+			func() tea.Msg {
+				return tuishell.SetStatusMsg{Content: "✓ Comment added"}
+			},
+		)
+
 	case issues.TransitionMsg:
 		m.pendingTransition = msg.Issue.Key
 		return m, func() tea.Msg {
@@ -122,6 +176,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tuishell.ConfirmPopoverYesMsg:
 		m.confirmPopover.Close()
+		if m.pendingComment != "" {
+			issueKey := m.pendingComment
+			body := m.Input.Value()
+			m.pendingComment = ""
+			m.Input.Reset()
+			return m, func() tea.Msg {
+				return tuishell.StartTaskMsg{Cmd: m.addComment(issueKey, body)}
+			}
+		}
 		issueKey := m.pendingTransition
 		transitionID := m.transitionIDByName[m.pendingTransitionName]
 		m.pendingTransition = ""
@@ -133,6 +196,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tuishell.ConfirmPopoverNoMsg:
 		m.confirmPopover.Close()
+		if m.pendingComment != "" {
+			m.pendingComment = ""
+			m.Input.Reset()
+		}
 		m.pendingTransition = ""
 		m.pendingTransitionName = ""
 		m.transitionIDByName = nil
@@ -272,8 +339,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// Route keys to textarea when focused (comment modal)
+	var cmds []tea.Cmd
+	if m.Input.Focused() {
+		var cmd tea.Cmd
+		m.Input, cmd = m.Input.Update(msg)
+		m.Shell.Modal.Content = m.Input.View()
+		cmds = append(cmds, cmd)
+	}
+
 	var cmd tea.Cmd
 	m.Shell, cmd = m.Shell.Update(msg)
+	cmds = append(cmds, cmd)
 	m.syncKeybinds()
 
 	// Sync panel pointer after shell update
@@ -287,7 +364,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Shell.Main = main
 	}
 
-	return m, cmd
+	return m, tea.Batch(cmds...)
 }
 
 func buildFilterSections(statuses, priorities, types map[string]bool, active jira.IssueFilters) []tuishell.FilterSection {

--- a/internal/tui/details/details.go
+++ b/internal/tui/details/details.go
@@ -18,6 +18,11 @@ import (
 	"github.com/felipeospina21/tuishell/table"
 )
 
+// CommentMsg is sent when the user wants to add a comment to an issue.
+type CommentMsg struct {
+	IssueKey string
+}
+
 // Model holds the state for the details side panel.
 type Model struct {
 	Viewport viewport.Model
@@ -54,6 +59,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		switch {
 		case match(Keybinds.Fullscreen):
 			return m, func() tea.Msg { return tuishell.ToggleFullscreenMsg{} }
+		case match(Keybinds.Comment):
+			if m.issue != nil {
+				issueKey := m.issue.Key
+				return m, func() tea.Msg { return CommentMsg{IssueKey: issueKey} }
+			}
 		}
 	case tea.WindowSizeMsg:
 		m.width = msg.Width

--- a/internal/tui/details/keys.go
+++ b/internal/tui/details/keys.go
@@ -9,12 +9,13 @@ import (
 
 type DetailsKeyMap struct {
 	Fullscreen key.Binding
+	Comment    key.Binding
 	tui.GlobalKeyMap
 }
 
 func (k DetailsKeyMap) ShortHelp() []key.Binding {
 	return slices.Concat(
-		[]key.Binding{k.Fullscreen},
+		[]key.Binding{k.Fullscreen, k.Comment},
 		tui.CommonKeys,
 	)
 }
@@ -22,7 +23,7 @@ func (k DetailsKeyMap) ShortHelp() []key.Binding {
 func (k DetailsKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		tui.CommonKeys,
-		{k.Fullscreen},
+		{k.Fullscreen, k.Comment},
 	}
 }
 
@@ -30,6 +31,10 @@ var Keybinds = DetailsKeyMap{
 	Fullscreen: key.NewBinding(
 		key.WithKeys("f"),
 		key.WithHelp("f", "fullscreen"),
+	),
+	Comment: key.NewBinding(
+		key.WithKeys("C"),
+		key.WithHelp("C", "comment"),
 	),
 	GlobalKeyMap: tui.GlobalKeys(false),
 }


### PR DESCRIPTION
## Summary

Add the ability to post a comment on a Jira issue from the details panel.

## Changes

- **API**: `AddComment(issueKey, body)` in `client.go` — calls `POST /rest/api/2/issue/{issueKey}/comment`, with dev mode simulation
- **Keybinding**: `C` (capitalized, mutation convention) added to details panel keybinds
- **Flow**: View issue details → `C` → textarea modal → type comment → `ctrl+s` → confirmation popover → confirm → API call → statusline feedback
- **Model**: `textarea.Model` + `pendingComment` field on the app model

## What was tested

- `make build` and `make test` pass
- Dev mode: modal opens, textarea accepts input, confirmation flow works

Closes #5